### PR TITLE
Make iCal files download instead of display inline

### DIFF
--- a/app/controllers/icalendars_controller.rb
+++ b/app/controllers/icalendars_controller.rb
@@ -40,6 +40,6 @@ class IcalendarsController < ApplicationController
         end
       end
 
-    render plain: calendar.to_ical
+    send_data calendar.to_ical, filename: 'oncall.ics', type: 'text/calendar', disposition: 'attachment'
   end
 end


### PR DESCRIPTION
At the moment clicking the iCal thing opens it as plain text in the
user's browser, leaving them to work out how to get it into their
calendar.

Using `send_data` instead will set the appropriate headers so the
browser downloads the file instead of opening it inline.