### PR TITLE
Another README list un-joining

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is an app to aggregate all of the rotas that we have at GDS.
 
 ### Features:
 
-- Aggregate calendars from PagerDuty Replacement for spreadsheet rotas (if
-  PagerDuty is not required/superfluous)
+- Aggregate calendars from PagerDuty
+- Replacement for spreadsheet rotas (if PagerDuty is not required/superfluous)
 - Annual leave tracking
 - Automatically finds conflicts between annual leave and rotas
 


### PR DESCRIPTION
The previous PR (#9) left two list items joined. This commit fixes that.