### PR TITLE
Rescue a failed login exception with a human error message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,8 @@ class ApplicationController < ActionController::Base
   before_action :maybe_expire_session
   before_action :maybe_redirect_if_not_signed_in
 
-  rescue_from ActionController::RoutingError do
-    redirect_to root_path, alert: 'Login failed. Did you use a GDS Google account?'
+  rescue_from Rotas::Errors::AuthorisationError do
+    redirect_to new_session_path, alert: Rotas::Errors::AuthorisationError.message
   end
 
 private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,7 +26,7 @@ class SessionsController < ApplicationController
     code  = params[:code]
 
     unless state == session[:state]
-      raise ActionController::RoutingError.new('Forbidden')
+      raise Rotas::Errors::AuthorisationError
     end
 
     payload = {
@@ -54,7 +54,7 @@ class SessionsController < ApplicationController
     email     = me_parsed['email']
 
     unless Rotas::Authorisation.email_authorised?(email)
-      raise ActionController::RoutingError.new('Forbidden')
+      raise Rotas::Errors::AuthorisationError
     end
 
     session[:email]        = email

--- a/app/lib/rotas/errors/authorisation_error.rb
+++ b/app/lib/rotas/errors/authorisation_error.rb
@@ -1,0 +1,7 @@
+module Rotas::Errors
+  class AuthorisationError < Exception
+    def self.message
+      'Authorisation error, are you using a GDS Google account?'
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,17 @@
 
     <div class="govuk-width-container">
       <%= render partial: 'layouts/phase' %>
+
+      <% if flash[:alert] %>
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+            <%= flash[:alert] %>
+          </strong>
+        </div>
+      <% end %>
+
       <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
         <%= yield %>
       </main>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -4,12 +4,6 @@
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-<% if flash[:alert] %>
-  <div class="govuk-error-message"><%= flash[:alert] %></div>
-
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-<% end %>
-
 <h1 class="govuk-heading-xl">
   Currently on rotas
 </h1>


### PR DESCRIPTION
- I recently signed into this with my personal Google account instead of
  my work one, and it kicked me back to a default Rails 403 page. This
  isn't the best user experience, so I've added a redirect to root_path
  with some words in a styled error message, to tell the user what
  happened.
- I have assumed here that ActionController::RoutingError is purely for
  failed logins (of the email address variety). Changing the raised
  exception for email address failures was out of scope.