### PR TITLE
enable Sub Resource Integrity (SRI) for JS & CSS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# for SRI
+gem 'sprockets-rails'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ DEPENDENCIES
   redcarpet
   sass-rails (~> 5.0)
   selenium-webdriver
+  sprockets-rails
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload', integrity: true %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', integrity: true %>
 
     <link rel="shortcut icon"
           href="<%= image_path('images/favicon') %>"


### PR DESCRIPTION
See also https://github.com/alphagov/verify-frontend/commit/8846701e0b3a7c82047a9ef75e620b7694519138

Note SRI is only served over TLS, so you don't see the tags locally