### PR TITLE
Add edit pager duty calendar functionality

### DIFF
--- a/app/controllers/pager_duty_calendars_controller.rb
+++ b/app/controllers/pager_duty_calendars_controller.rb
@@ -1,0 +1,15 @@
+class PagerDutyCalendarsController < ApplicationController
+  def edit
+    @calendar = PagerDutyCalendar.find(params[:id])
+  end
+
+  def update
+    @calendar = PagerDutyCalendar.find(params[:id])
+    @calendar.assign_attributes(params.permit(:name, :url))
+
+    return render :edit unless @calendar.valid?
+
+    @calendar.save
+    redirect_to pager_duty_calendar_path(@calendar)
+  end
+end

--- a/app/lib/rotas/errors/authorisation_error.rb
+++ b/app/lib/rotas/errors/authorisation_error.rb
@@ -1,5 +1,5 @@
 module Rotas::Errors
-  class AuthorisationError < Exception
+  class AuthorisationError < Exception # rubocop:disable Lint/InheritException
     def self.message
       'Authorisation error, are you using a GDS Google account?'
     end

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -30,6 +30,10 @@
     <%= link_to manual_calendar_events_path(@calendar.id), class: 'govuk-button' do %>
       View, add, and edit events
     <% end %>
+  <% else %>
+    <%= link_to edit_pager_duty_calendar_path(@calendar), class: 'govuk-button' do %>
+      Edit calendar
+    <% end %>
   <% end %>
 </div>
 

--- a/app/views/pager_duty_calendars/edit.html.erb
+++ b/app/views/pager_duty_calendars/edit.html.erb
@@ -1,0 +1,59 @@
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to '/', class: 'govuk-breadcrumbs__link' do %>Home<% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to teams_path, class: 'govuk-breadcrumbs__link' do %>
+        Teams
+      <% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to team_path(@calendar.team), class: 'govuk-breadcrumbs__link' do %>
+        <%= @calendar.team.name %>
+      <% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to edit_pager_duty_calendar_path(@calendar),
+                  class: 'govuk-breadcrumbs__link' do %>
+        Edit calendar
+      <% end %>
+    </li>
+  </ol>
+</div>
+
+<h1 class="govuk-heading-xl">
+  Edit calendar
+</h1>
+
+<%= form_tag pager_duty_calendar_path(@calendar), method: :patch do %>
+  <% unless @calendar.errors.empty? %>
+    <ul class="govuk-list govuk-list--bullet">
+      <% @calendar.errors.full_messages.each do |message| %>
+        <li><span class="govuk-error-message"><%= message %></span></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <div class="govuk-form-group">
+        <%= label_tag :name, class: 'govuk-label' do %>
+          Calendar name
+        <% end %>
+        <%= text_field_tag :name, @calendar.name, class: 'govuk-input' %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= label_tag :url, class: 'govuk-label' do %>
+          Calendar URL
+        <% end %>
+        <%= text_field_tag :url, @calendar.url, class: 'govuk-input' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-form-group">
+    <%= submit_tag 'Update calendar', class: 'govuk-button' %>
+  </div>
+<% end %>

--- a/config/initializers/url_cache.rb
+++ b/config/initializers/url_cache.rb
@@ -1,6 +1,7 @@
 class UrlCache
   def initialize
     @cache = {}
+    @jobs  = Set.new
     @mutex = Mutex.new
   end
 
@@ -8,7 +9,16 @@ class UrlCache
     @mutex.synchronize { @cache[url] = body }
   end
 
+  def watch(url)
+    unless @jobs.include?(url)
+      UrlFetcherJob.perform_later(url)
+      @jobs.add(url)
+    end
+  end
+
   def fetch(url)
+    watch(url)
+
     loop do
       result = @mutex.synchronize { @cache.fetch(url, nil) }
       return result unless result.nil?
@@ -25,6 +35,6 @@ end
 unless $0.match?(/rake/)
   PagerDutyCalendar.all.each do |calendar|
     Rails.logger.info "Starting url fetcher job for #{calendar.url}"
-    UrlFetcherJob.perform_later calendar.url
+    Rotas::URL_CACHE.watch(calendar.url)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,18 @@ Rails.application.routes.draw do
       action: :callback,
       as: 'callback_session'
 
+  get 'calendars/:id/edit',
+      id: /pagerduty:.*/,
+      controller: :pager_duty_calendars,
+      action: :edit,
+      as: 'edit_pager_duty_calendar'
+
+  patch 'calendars/:id',
+        id: /pagerduty:.*/,
+        controller: :pager_duty_calendars,
+        action: :update,
+        as: 'pager_duty_calendar'
+
   if %w(test development).include? Rails.env
     post 'test_session_create', to: 'test_session#create', as: :test_session_create
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   root 'pages#home'
 
@@ -40,3 +41,4 @@ Rails.application.routes.draw do
     post 'test_session_create', to: 'test_session#create', as: :test_session_create
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'pages#home'
 
   resources :teams, only: %i(index show new create edit update)
-  get 'team/:id/conflicts',
+  get 'teams/:id/conflicts',
     as: 'team_conflicts',
     controller: :teams,
     action: :conflicts

--- a/test/integration/pager_duty_calendars_test.rb
+++ b/test/integration/pager_duty_calendars_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+require 'helpers/auth_helper'
+require 'time'
+
+class PagerDutyCalendarsTest < ActionDispatch::IntegrationTest
+  setup do
+    @team     = Team.create(name: 'myteam')
+    @calendar = PagerDutyCalendar.create(
+      name: 'mypdcal',
+      url:  'https://example.com',
+      team: @team,
+      clock_type: :in_hours,
+    )
+  end
+
+  teardown do
+    @calendar.delete
+    @team.delete
+  end
+
+  test "pagerduty calendars work correctly" do
+    create_test_session_with_fake_auth
+
+    get edit_pager_duty_calendar_path(@calendar.id)
+    assert_response :success
+
+    patch pager_duty_calendar_path(@calendar.id),
+          params: {
+            id:   @calendar.id,
+            name: 'mypdcalchanged',
+            url:  'https://gov.uk',
+          }
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+
+    calendar = PagerDutyCalendar.find(@calendar.id)
+    assert_equal calendar.name, 'mypdcalchanged'
+    assert_equal calendar.url,  'https://gov.uk'
+  end
+end


### PR DESCRIPTION
What
----

Allows one to edit the name and descriptions of pagerduty calendars

Why
---

We are moving to a centralised pagerduty so we will have to update a bunch of
calendars, ideally not through the console

---

solo @ltwr