### PR TITLE
Show the rota before the team members on the calendar page

### DIFF
--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -38,19 +38,6 @@
 </div>
 
 <div>
-  <h2 class="govuk-heading-l">Calendar members</h2>
-  <ul class="govuk-list govuk-list--bullet">
-    <% @team_members.each do |email| %>
-      <li>
-        <%= link_to user_path(email), class: 'govuk-link' do %>
-          <%= email_fmt(email) %>
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
-</div>
-
-<div>
   <h2 class="govuk-heading-l">Schedule</h2>
   <div>
     <%= link_to url_for(all: true), class: 'govuk-button' do %>
@@ -82,4 +69,17 @@
       <% end %>
     </tbody>
   </table>
+</div>
+
+<div>
+  <h2 class="govuk-heading-l">Calendar members</h2>
+  <ul class="govuk-list govuk-list--bullet">
+    <% @team_members.each do |email| %>
+      <li>
+        <%= link_to user_path(email), class: 'govuk-link' do %>
+          <%= email_fmt(email) %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
 </div>


### PR DESCRIPTION
- Scrolling down a page before you get to 'who's on the rota now' is frustrating.