### PR TITLE
Move emails into a text column

### DIFF
--- a/app/models/manual_calendar_event.rb
+++ b/app/models/manual_calendar_event.rb
@@ -5,6 +5,8 @@ class ManualCalendarEvent < ApplicationRecord
   validates :end_date,   presence: true
   validate :end_date_after_start_date?
 
+  serialize :emails_text, Array
+
 private
 
   def end_date_after_start_date?

--- a/app/models/manual_calendar_event.rb
+++ b/app/models/manual_calendar_event.rb
@@ -5,7 +5,7 @@ class ManualCalendarEvent < ApplicationRecord
   validates :end_date,   presence: true
   validate :end_date_after_start_date?
 
-  serialize :emails_text, Array
+  serialize :emails, Array
 
 private
 

--- a/db/migrate/20190731081757_add_emails_text_to_manual_calendar_events.rb
+++ b/db/migrate/20190731081757_add_emails_text_to_manual_calendar_events.rb
@@ -1,0 +1,5 @@
+class AddEmailsTextToManualCalendarEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :manual_calendar_events, :emails_text, :text
+  end
+end

--- a/db/migrate/20190731082701_copy_emails_to_emails_text_on_manual_calendar_events.rb
+++ b/db/migrate/20190731082701_copy_emails_to_emails_text_on_manual_calendar_events.rb
@@ -1,0 +1,11 @@
+class CopyEmailsToEmailsTextOnManualCalendarEvents < ActiveRecord::Migration[5.2]
+  def up
+    ManualCalendarEvent.all.each do |event|
+      event.emails_text = event.emails
+      event.save
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20190731083807_drop_emails_from_manual_calendar_events.rb
+++ b/db/migrate/20190731083807_drop_emails_from_manual_calendar_events.rb
@@ -1,0 +1,6 @@
+class DropEmailsFromManualCalendarEvents < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :manual_calendar_events, :emails
+    rename_column :manual_calendar_events, :emails_text, :emails
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_081757) do
+ActiveRecord::Schema.define(version: 2019_07_31_082701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_082701) do
+ActiveRecord::Schema.define(version: 2019_07_31_083807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,10 +29,9 @@ ActiveRecord::Schema.define(version: 2019_07_31_082701) do
     t.string "manual_calendar_id"
     t.date "start_date"
     t.date "end_date"
-    t.string "emails", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "emails_text"
+    t.text "emails"
   end
 
   create_table "manual_calendars", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_08_174953) do
+ActiveRecord::Schema.define(version: 2019_07_31_081757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2018_11_08_174953) do
     t.string "emails", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "emails_text"
   end
 
   create_table "manual_calendars", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,8 @@ ActiveRecord::Schema.define(version: 2018_11_08_174953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "postgis"
+  enable_extension "uuid-ossp"
 
   create_table "annual_leave_events", force: :cascade do |t|
     t.string "email"
@@ -51,6 +53,13 @@ ActiveRecord::Schema.define(version: 2018_11_08_174953) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["team_id"], name: "index_pager_duty_calendars_on_team_id"
+  end
+
+  create_table "spatial_ref_sys", primary_key: "srid", id: :integer, default: nil, force: :cascade do |t|
+    t.string "auth_name", limit: 256
+    t.integer "auth_srid"
+    t.string "srtext", limit: 2048
+    t.string "proj4text", limit: 2048
   end
 
   create_table "teams", force: :cascade do |t|


### PR DESCRIPTION
Context
----

Currently we use Postgres for our development, test, AND production database; this is annoying for CI/CD. We currently MUST use Postgres because we have an `Array` column on `ManualCalendarEvent` which is Postgres specific.

We can use `serialize` with `Array` on the model and then be able to use Postgres OR Sqlite

What
----

This PR moves the column `emails` to `emails` via a temporary column `emails_text`.

How to review
----

Code review

If you're a good citizen you could get a dump of `rotas-db`, remove all the PaaS specific SQL, then run the migrations. I've done this already locally.