### PR TITLE
Feature: get contact information from a user's page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,7 @@
 //= require_tree .
 //= require_self
 
-@import "govuk-frontend/all";
+@import "govuk-frontend/govuk/all";
 
 .govuk-table.govuk-table--small {
   font-size: 12px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,6 +47,7 @@ private
   end
 
   def current_user
+    return 'disable@auth.user' if ENV.fetch('DISABLE_AUTH', nil)
     session.fetch(:email, nil)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  helper_method :name_fmt
   helper_method :email_fmt
   helper_method :current_user_is_email
   helper_method :current_user
@@ -12,6 +13,13 @@ class ApplicationController < ActionController::Base
   end
 
 private
+  def name_fmt(email)
+    short = email.split('.').first.capitalize
+
+    return short unless email&.casecmp(current_user)&.zero?
+
+    '<strong class="govuk-tag">You</strong>'.html_safe
+  end
 
   def email_fmt(email)
     return email unless email.end_with?('digital.cabinet-office.gov.uk')

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,5 +39,7 @@ class UsersController < ApplicationController
         message: "Viewed #{@email}",
       }
     ).save!
+
+    @contact_details = Rotas::PagerdutyAPI.contact_details_for_email(@email)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
     AuditEvent.new(
       email: current_user,
       event: {
-        message: "Viewed #{@email}",
+        message: "Viewed the contact details of #{@email} from PagerDuty",
       }
     ).save!
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,6 +40,6 @@ class UsersController < ApplicationController
       }
     ).save!
 
-    @contact_details = Rotas::PagerdutyAPI.contact_details_for_email(@email)
+    @contact_details = Rotas::PagerDutyAPI.contact_details_for_email(@email)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,4 +29,15 @@ class UsersController < ApplicationController
       @days_until_rota = @next_rota_date - Date.today
     end
   end
+
+  def contact_information
+    @email = params[:id]
+
+    AuditEvent.new(
+      email: current_user,
+      event: {
+        message: "Viewed #{@email}",
+      }
+    ).save!
+  end
 end

--- a/app/lib/rotas/pager_duty_api.rb
+++ b/app/lib/rotas/pager_duty_api.rb
@@ -1,4 +1,4 @@
-module Rotas::PagerdutyAPI
+module Rotas::PagerDutyAPI
   def self.contact_details_for_email(email)
     users_url = "#{api_url}/users"
 

--- a/app/lib/rotas/pagerduty_api.rb
+++ b/app/lib/rotas/pagerduty_api.rb
@@ -1,5 +1,46 @@
 module Rotas::PagerdutyAPI
   def self.contact_details_for_email(email)
-    raise 'not implemented'
+    users_url = "#{api_url}/users"
+
+    user_response = HTTP
+      .headers(default_headers)
+      .get(users_url, params: {query: email})
+
+    user = JSON.parse(user_response).dig('users').first
+
+    return nil if user.nil?
+
+    contact_methods_url = "#{api_url}/users/#{user['id']}/contact_methods"
+
+    contact_methods_response = HTTP
+      .headers(default_headers)
+      .get(contact_methods_url)
+
+    contact_methods = JSON
+      .parse(contact_methods_response)
+      .dig('contact_methods')
+  end
+
+  private
+
+  def self.api_url
+    'https://api.pagerduty.com/'
+  end
+
+  def self.default_headers
+    {
+      accept: 'application/vnd.pagerduty+json;version=2',
+      authorization: "Token token=#{api_key}",
+    }
+  end
+
+  def self.api_key
+    if ENV.key?('VCAP_SERVICES')
+      CF::App::Credentials
+          .find_by_service_name('rotas-secrets')
+          .find_by_service_name('pagerduty-api-key')
+    else
+      ENV.fetch('PAGERDUTY_API_KEY')
+    end
   end
 end

--- a/app/lib/rotas/pagerduty_api.rb
+++ b/app/lib/rotas/pagerduty_api.rb
@@ -1,0 +1,5 @@
+module Rotas::PagerdutyAPI
+  def self.contact_details_for_email(email)
+    raise 'not implemented'
+  end
+end

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -1,0 +1,11 @@
+class AuditEvent < ApplicationRecord
+  validates :email, presence: true
+
+  validates_each :event do |record, attr, val|
+    if attr == :event && !val.is_a?(Hash) && !val.key?(:message)
+      record.errors.add(attr, 'must include a :message in the event')
+    end
+  end
+
+  serialize :event, Hash
+end

--- a/app/views/users/contact_information.html.erb
+++ b/app/views/users/contact_information.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to '/', class: 'govuk-breadcrumbs__link' do %>Home<% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      Users
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to user_path(@email), class: 'govuk-breadcrumbs__link' do %>
+        <%= @email %>
+      <% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to user_contact_information_path(@email), class: 'govuk-breadcrumbs__link' do %>
+        Contact information
+      <% end %>
+    </li>
+  </ol>
+</div>
+
+<h1 class="govuk-heading-l">
+  Contact details
+</h1>
+
+<p class="govuk-body">
+  This has been logged in the audit log
+</p>

--- a/app/views/users/contact_information.html.erb
+++ b/app/views/users/contact_information.html.erb
@@ -20,9 +20,44 @@
 </div>
 
 <h1 class="govuk-heading-l">
-  Contact details
+  Contact details for <%= email_fmt(@email) %>
 </h1>
 
 <p class="govuk-body">
-  This has been logged in the audit log
+  This has been logged in the audit log.
 </p>
+
+<% if @contact_details.nil? || @contact_details.empty? %>
+  <p class="govuk-body">
+  There are no contact details in Pagerduty for <%= name_fmt(@email) %>.
+  </p>
+<% else %>
+  <table class="govuk-summary-list">
+    <tbody class="govuk-table__body">
+      <% @contact_details.each do |detail| %>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header govuk-!-width-one-quarter">
+            <%= detail['type'].split('_').first.capitalize.gsub(/sms/i, 'SMS') %>
+          </th>
+          <td class="govuk-table__cell govuk-!-width-one-quarter">
+            <%= detail['label'] %>
+          </td>
+          <td class="govuk-table__cell govuk-!-width-one-half">
+            <% if detail['type'].match?(/sms|phone/i) %>
+              <%= link_to "tel:#{detail['country_code']}#{detail['address']}",
+                          class: 'govuk-link' do %>
+                +<%= detail['country_code'] %>
+                <%= detail['address'] %>
+              <% end %>
+            <% end %>
+            <% if detail['type'].match?(/email/i) %>
+              <%= link_to "mailto:#{detail['address']}", class: 'govuk-link' do %>
+                <%= detail['address'] %>
+              <% end %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/users/contact_information.html.erb
+++ b/app/views/users/contact_information.html.erb
@@ -29,7 +29,7 @@
 
 <% if @contact_details.nil? || @contact_details.empty? %>
   <p class="govuk-body">
-  There are no contact details in Pagerduty for <%= name_fmt(@email) %>.
+  There are no contact details in PagerDuty for <%= name_fmt(@email) %>.
   </p>
 <% else %>
   <table class="govuk-summary-list">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,11 +19,11 @@
 </h1>
 
 <p class="govuk-body">
-  Click the button below to fetch contact information from Pagerduty.
+  Click the button below to fetch contact information from PagerDuty.
 </p>
 
 <%= link_to user_contact_information_path(@email), class: 'govuk-button' do %>
-  Get contact information from Pagerduty
+  Get contact information from PagerDuty
 <% end %>
 
 <p class="govuk-body">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,11 +18,25 @@
   Contact details
 </h1>
 
+<p class="govuk-body">
+  Click the button below to fetch contact information from Pagerduty.
+</p>
+
+<%= link_to user_contact_information_path(@email), class: 'govuk-button' do %>
+  Get contact information from Pagerduty
+<% end %>
 
 <p class="govuk-body">
-  <%= email_fmt(@email) %> may or may not have contact details available on
-  <%= link_to 'People Finder', people_finder_url(@email) %>, otherwise
-  check <%= link_to 'Google Contacts', 'https://contacts.google.com' %>.
+  Accessing contact information is recorded in the audit log.
+</p>
+
+<p class="govuk-body">
+  Alternatively,
+  <%= name_fmt(@email) %>
+  may have contact details available on
+  <%= link_to 'People Finder', people_finder_url(@email) %>,
+  or
+  <%= link_to 'Google Contacts', 'https://contacts.google.com' %>.
 </p>
 
 <h1 class="govuk-heading-l">

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,7 +15,7 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 # This is to get govuk-frontend fonts
 Rails.application.config.assets.paths << Rails.root.join(
-  'node_modules/govuk-frontend/assets/'
+  'node_modules/govuk-frontend/govuk/assets/'
 )
 
 # Rails needs to know about the file extensions for our fonts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,12 @@ Rails.application.routes.draw do
   end
   resources :annual_leave_events, only: %i(index new create edit update destroy)
 
-  resources :users, only: %i(show), id: /.*/
+  resources :users, only: %i(show), id: /[^\/]*/
+  get 'users/:id/contact-info',
+      id: /[^\/]*/,
+      controller: :users,
+      action: :contact_information,
+      as: :user_contact_information
 
   resource :session, only: %i(new create destroy)
   get 'session/callback',

--- a/db/migrate/20190731211302_create_audit_events.rb
+++ b/db/migrate/20190731211302_create_audit_events.rb
@@ -1,0 +1,10 @@
+class CreateAuditEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :audit_events do |t|
+      t.string :email
+      t.text :event
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_083807) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-  enable_extension "postgis"
-  enable_extension "uuid-ossp"
+ActiveRecord::Schema.define(version: 2019_07_31_211302) do
 
   create_table "annual_leave_events", force: :cascade do |t|
     t.string "email"
     t.date "start_date"
     t.date "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "audit_events", force: :cascade do |t|
+    t.string "email"
+    t.text "event"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -55,7 +57,7 @@ ActiveRecord::Schema.define(version: 2019_07_31_083807) do
     t.index ["team_id"], name: "index_pager_duty_calendars_on_team_id"
   end
 
-  create_table "spatial_ref_sys", primary_key: "srid", id: :integer, default: nil, force: :cascade do |t|
+  create_table "spatial_ref_sys", primary_key: "srid", force: :cascade do |t|
     t.string "auth_name", limit: 256
     t.integer "auth_srid"
     t.string "srtext", limit: 2048
@@ -70,6 +72,4 @@ ActiveRecord::Schema.define(version: 2019_07_31_083807) do
     t.string "slug"
   end
 
-  add_foreign_key "manual_calendars", "teams"
-  add_foreign_key "pager_duty_calendars", "teams"
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "govuk-frontend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-1.2.0.tgz",
-      "integrity": "sha512-pHKghu9J1nB7F/MKpiYaimPoJXUJdmMZUGuORv9K1Ek1sVNdTRlEKR+rogpfR4GkroS0tS1LMwQJrQkiCvxIIw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
+      "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "gds-rotas",
   "private": true,
   "dependencies": {
-    "govuk-frontend": "^1.2.0"
+    "govuk-frontend": "^3.0.0"
   }
 }

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -15,6 +15,18 @@ class ApplicationControllerTest < ActionController::TestCase
     end
   end
 
+  test 'name_fmt works' do
+    emails = %w[
+      firstname.lastname1@digital.cabinet-office.gov.uk
+      firstname.middlenamelastname-lastname@digital.cabinet-office.gov.uk
+    ]
+    nices = ['Firstname', 'Firstname']
+
+    emails.zip(nices).each do |email, nice|
+      assert_equal @controller.send(:name_fmt, email), nice
+    end
+  end
+
   test 'email_fmt works' do
     emails = %w[
       firstname.lastname1@digital.cabinet-office.gov.uk

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -50,7 +50,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       assert_equal audit_event.email, test_session_email
 
-      assert_equal audit_event.event[:message], "Viewed #{email}"
+      assert_equal audit_event.event[:message],
+                   "Viewed the contact details of #{email} from PagerDuty"
 
       assert_select 'th', /Email/
       assert_select 'td', /email-address/
@@ -90,7 +91,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       assert_equal audit_event.email, test_session_email
 
-      assert_equal audit_event.event[:message], "Viewed #{email}"
+      assert_equal audit_event.event[:message],
+                   "Viewed the contact details of #{email} from PagerDuty"
 
       assert_select 'p', /There are no contact details in PagerDuty/
     end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -5,7 +5,7 @@ require 'helpers/teams_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   test 'should log an audit event and show contact details correctly' do
-    Rotas::PagerdutyAPI.stub(
+    Rotas::PagerDutyAPI.stub(
       :contact_details_for_email, [
         {
           'type'    => 'email_contact_method',
@@ -78,7 +78,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should log an audit event and show a helpful msg when no details' do
-    Rotas::PagerdutyAPI.stub(:contact_details_for_email, nil) do
+    Rotas::PagerDutyAPI.stub(:contact_details_for_email, nil) do
       create_test_session_with_fake_auth
 
       email = 'log-an-audit-event-404@test'
@@ -92,7 +92,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       assert_equal audit_event.event[:message], "Viewed #{email}"
 
-      assert_select 'p', /There are no contact details in Pagerduty/
+      assert_select 'p', /There are no contact details in PagerDuty/
     end
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+require 'helpers/auth_helper'
+require 'helpers/teams_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test 'should log an audit event' do
+    create_test_session_with_fake_auth
+
+    email = 'log-an-audit-event@test'
+
+    get user_contact_information_path(id: email)
+    assert_response :success
+
+    audit_event = AuditEvent.last
+
+    assert_equal audit_event.email, test_session_email
+
+    assert_equal audit_event.event[:message], "Viewed #{email}"
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,20 +1,79 @@
 require 'test_helper'
+require 'minitest/mock'
 require 'helpers/auth_helper'
 require 'helpers/teams_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   test 'should log an audit event' do
-    create_test_session_with_fake_auth
+    Rotas::PagerdutyAPI.stub(
+      :contact_details_for_email, [
+        {
+          'type'    => 'email_contact_method',
+          'address' => 'email-address',
+          'label'   => 'Work email',
+        },
+        {
+          'type'    => 'email_contact_method',
+          'address' => 'email2-address',
+          'label'   => 'Home email',
+        },
+        {
+          'type'    => 'phone_contact_method',
+          'address' => 'phone-address',
+          'label'   => 'Work phone',
+        },
+        {
+          'type'    => 'phone_contact_method',
+          'address' => 'phone2-address',
+          'label'   => 'Home phone',
+        },
+        {
+          'type'    => 'sms_contact_method',
+          'address' => 'sms-address',
+          'label'   => 'Work SMS',
+        },
+        {
+          'type'    => 'push_notification_contact_method',
+          'address' => 'push-address',
+          'label'   => 'Work push',
+        },
+      ]
+    ) do
+      create_test_session_with_fake_auth
 
-    email = 'log-an-audit-event@test'
+      email = 'log-an-audit-event@test'
 
-    get user_contact_information_path(id: email)
-    assert_response :success
+      get user_contact_information_path(id: email)
+      assert_response :success
 
-    audit_event = AuditEvent.last
+      audit_event = AuditEvent.last
 
-    assert_equal audit_event.email, test_session_email
+      assert_equal audit_event.email, test_session_email
 
-    assert_equal audit_event.event[:message], "Viewed #{email}"
+      assert_equal audit_event.event[:message], "Viewed #{email}"
+
+      assert_select 'th', /Email/
+      assert_select 'td', /email-address/
+      assert_select 'td', /Work email/
+      assert_select 'td', /email2-address/
+      assert_select 'td', /Home email/
+
+      assert_select 'th', /Phone/
+      assert_select 'td', /phone-address/
+      assert_select 'td', /Work phone/
+      assert_select 'td', /phone2-address/
+      assert_select 'td', /Home phone/
+
+      assert_select 'th', /SMS/
+      assert_select 'td', /sms-address/
+      assert_select 'td', /Work SMS/
+
+      assert_select 'th', /Push/
+      assert_select 'td', {
+        text: /push-address/,
+        count: 0,
+      }, 'Hide push address as it is meaningless'
+      assert_select 'td', /Work push/
+    end
   end
 end

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -1,3 +1,7 @@
 def create_test_session_with_fake_auth
     post test_session_create_path
 end
+
+def test_session_email
+  'emailyemail.emailyemail@digital.cabinet-office.gov.uk'
+end

--- a/test/models/audit_event_test.rb
+++ b/test/models/audit_event_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class AuditEventTest < ActiveSupport::TestCase
+  test 'happy path' do
+    assert_empty AuditEvent.new(
+      email: 'foo@bar.com',
+      event: {
+        message: 'did a thing'
+      },
+    ).errors
+  end
+
+  test 'email cannot be empty' do
+    assert_empty AuditEvent.new(
+      event: {
+        message: 'did a thing'
+      },
+    ).errors
+  end
+
+  test 'event cannot be empty' do
+    assert_empty AuditEvent.new(
+      email: 'foo@bar.com',
+    ).errors
+  end
+end


### PR DESCRIPTION
~___This PR is based off #84, once that is merged I will rebase. It will help you test it out locally though.___~

User stories
---

> As someone who is on a rota, I need to get the contact details for someone on a different rota, so I can contact them in an emergency.

Currently only Pagerduty global admins can see _everyone_ in Pagerduty, which means not everyone who is on-call can contact everyone else.

Not everyone has their People Finder or Google Contacts up to date. We are much more strict about ensuring Pagerduty is up to date.

> As someone who is NOT on a rota, I need to get the contact details for someone who is presently on-call, so I can contact them in an emergency.

There are a number of _stakeholders_ who do not have Pagerduty accounts (because they are expensive), who are currently able to see who is currently on call, using the rotas app.

However they are unable to contact the people who are currently on the rota because they do not have Pagerduty accounts, nor would they unless they were Pagerduty global admins.

Other solutions to this problem have been tried:
- Giving the _stakeholders_ Pagerduty accounts
  - Vetoed because expensive
  - _Stakeholders_ did not accept invites, or could not use Pagerduty because it is not user-friendly
- The vexatious distribution of spreadsheets, where on-call engineers were expected to put their phone numbers
  - These went partially unfilled
  - People forgot to update the sheets, or could not find the sheets
  - IA position unclear on whether copious amounts of contact data should be stored in Google drive

This can be solved by _reading from Pagerduty directly_ and _not storing any of the PII_.

> As someone who works in information assurance, I need to know who accessed someone's contact details, for audit and compliance reasons.

(This is allegedly a user need, but I haven't confirmed the _actual_ need)

What
---

Adds a button to a user's page

![Screen Shot 2019-08-01 at 10 20 33](https://user-images.githubusercontent.com/1482692/62281469-ba215300-b445-11e9-96a4-8df1d66aeedc.png)
_Image of "Get contact information from Pagerduty"_ button, on the existing show user page_

![Screen Shot 2019-08-01 at 10 25 52](https://user-images.githubusercontent.com/1482692/62281905-7f6bea80-b446-11e9-93dc-f577ae8b80d5.png)
_Image of contact information table, on the new page_

Consequences
---

> Anyone with a `@digital.cabinet-office.gov.uk` email address will be able to get the contact details of anyone who is in Pagerduty.

I personally think this is beneficial to the organisation.

> We have an additional table in the database

It is for audit events, should be fine

> The rotas application will have read-only access to Pagerduty via the API

This is necessary for fulfilling the user need

How to review
---

Code review

Run the tests: `bundle install && bundle exec rake test`

Test it out locally:

- Generate a Pagerduty API key and put it in your environment `PAGERDUTY_API_TOKEN`
- Navigate to `toby.lornewelch-richards@digital.cabinet-office.gov.uk/contact-info`
- Steal my phone number
- ???
- Success