### PR TITLE
Prometheus gardening

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :test do
 end
 
 group :production do
-  gem 'gds_metrics'
+  gem 'prometheus-client', '~> 1.0'
   gem 'pg'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,8 +84,6 @@ GEM
     ffi (1.11.1)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
-    gds_metrics (0.1.0)
-      prometheus-client-mmap (= 0.9.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk-lint (4.0.1)
@@ -137,7 +135,7 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.1.4)
-    prometheus-client-mmap (0.9.1)
+    prometheus-client (1.0.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -253,13 +251,13 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   friendly_id
-  gds_metrics
   govuk-lint
   http
   icalendar
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg
+  prometheus-client (~> 1.0)
   pry
   puma (~> 3.11)
   rails (~> 5.2.2.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,10 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+require 'prometheus/client'
+require 'prometheus/client/data_stores/direct_file_store'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -40,5 +44,9 @@ module GdsRotas
       max_threads: 4,
       idletime: 600.seconds,
     )
+
+    config.middleware.use Prometheus::Middleware::Collector
+    config.middleware.use Prometheus::Middleware::Exporter
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: 'tmp/metrics')
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,8 +45,13 @@ Rails.application.configure do
   # config.action_cable.url = 'wss://example.com/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # Use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+
+  # Disable HTTPS redirect; PaaS will do HTTPS redirect for us anyway,
+  # and it interferes with Prometheus metric scraping (which happens
+  # locally over HTTP)
+  config.ssl_options = { redirect: false }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Make it possible for prometheus running on PaaS to scrape rotas.

This upgrades to the official prometheus ruby client 1.0 and removes the http->https redirect.

See commit messages for more context.