### PR TITLE
Add the concept of services

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,0 +1,48 @@
+class ServicesController < ApplicationController
+  def index
+    @services = Service.all
+  end
+
+  def show
+    @service = Service.friendly.find(params[:id])
+
+    description = @service.description || ''
+    @description = Rotas::MarkdownRenderer.render(description)
+
+    documentation = @service.documentation || ''
+    @documentation = Rotas::MarkdownRenderer.render(documentation)
+  end
+
+  def new
+    @service = Service.new
+  end
+
+  def edit
+    @service = Service.friendly.find(params[:id])
+  end
+
+  def create
+    @service = Service.new(params.permit(
+      :name,
+      :description, :documentation,
+    ))
+
+    return render :new unless @service.valid?
+
+    @service.save
+    redirect_to service_path(@service)
+  end
+
+  def update
+    @service = Service.friendly.find(params[:id])
+    @service.assign_attributes(params.permit(
+      :name,
+      :description, :documentation,
+    ))
+
+    return render :edit unless @service.valid?
+
+    @service.save
+    redirect_to service_path(@service)
+  end
+end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -15,19 +15,25 @@ class ServicesController < ApplicationController
 
   def new
     @service = Service.new
+    @teams = Team.all
   end
 
   def edit
     @service = Service.friendly.find(params[:id])
+    @teams = Team.all
   end
 
   def create
-    @service = Service.new(params.permit(
+    @service = Service.new(params.require(:service).permit(
       :name,
       :description, :documentation,
+      { team_ids: [] },
     ))
 
-    return render :new unless @service.valid?
+    unless @service.valid?
+      @teams = Team.all
+      return render :new
+    end
 
     @service.save
     redirect_to service_path(@service)
@@ -35,12 +41,16 @@ class ServicesController < ApplicationController
 
   def update
     @service = Service.friendly.find(params[:id])
-    @service.assign_attributes(params.permit(
+    @service.assign_attributes(params.require(:service).permit(
       :name,
       :description, :documentation,
+      { team_ids: [] },
     ))
 
-    return render :edit unless @service.valid?
+    unless @service.valid?
+      @teams = Team.all
+      return render :edit
+    end
 
     @service.save
     redirect_to service_path(@service)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,0 +1,3 @@
+class Service < ApplicationRecord
+  validates :name, presence: true
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,3 +1,13 @@
 class Service < ApplicationRecord
   validates :name, presence: true
+
+  def score
+    max_score = 2
+    score = 0
+
+    score += 1 unless description.blank?
+    score += 1 unless documentation.blank?
+
+    (score / max_score) * 5.0
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,4 +1,7 @@
 class Service < ApplicationRecord
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+
   validates :name, presence: true
 
   def score

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -7,11 +7,12 @@ class Service < ApplicationRecord
   validates :name, presence: true
 
   def score
-    max_score = 2
+    max_score = 3.0
     score = 0
 
     score += 1 unless description.blank?
     score += 1 unless documentation.blank?
+    score += 1 unless teams.empty?
 
     (score / max_score) * 5.0
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,6 +2,8 @@ class Service < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :slugged
 
+  has_and_belongs_to_many :teams
+
   validates :name, presence: true
 
   def score

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,8 +1,10 @@
 class Team < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :slugged
+
   has_many :pagerduty_calendars, class_name: :PagerDutyCalendar
   has_many :manual_calendars,    class_name: :ManualCalendar
+  has_and_belongs_to_many :services
 
   validates :name, presence: true
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -33,13 +33,18 @@
       <nav>
         <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
           <li class="govuk-header__navigation-item">
-            <%= link_to(teams_path, class: 'govuk-header__link') do %>
-              Teams
+            <%= link_to(calendars_path, class: 'govuk-header__link') do %>
+              Calendars
             <% end %>
           </li>
           <li class="govuk-header__navigation-item">
-            <%= link_to(calendars_path, class: 'govuk-header__link') do %>
-              Calendars
+            <%= link_to(services_path, class: 'govuk-header__link') do %>
+              Services
+            <% end %>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <%= link_to(teams_path, class: 'govuk-header__link') do %>
+              Teams
             <% end %>
           </li>
           <li class="govuk-header__navigation-item">

--- a/app/views/services/_form.html.erb
+++ b/app/views/services/_form.html.erb
@@ -1,0 +1,30 @@
+<% unless @service.errors.empty? %>
+  <ul class="govuk-list govuk-list--bullet">
+    <% @service.errors.full_messages.each do |message| %>
+      <li><span class="govuk-error-message"><%= message %></span></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-form-group">
+      <%= label_tag :name, class: 'govuk-label' do %>
+        Service name
+      <% end %>
+      <%= text_field_tag :name, @service.name, class: 'govuk-input' %>
+    </div>
+    <div class="govuk-form-group">
+      <%= label_tag :description, class: 'govuk-label' do %>
+        Description
+      <% end %>
+      <%= text_area_tag :description, @service.description, rows: 5, class: 'govuk-textarea' %>
+    </div>
+    <div class="govuk-form-group">
+      <%= label_tag :documentation, class: 'govuk-label' do %>
+        Documentation
+      <% end %>
+      <%= text_area_tag :documentation, @service.documentation, rows: 5, class: 'govuk-textarea' %>
+    </div>
+  </div>
+</div>

--- a/app/views/services/_form.html.erb
+++ b/app/views/services/_form.html.erb
@@ -9,22 +9,33 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <div class="govuk-form-group">
-      <%= label_tag :name, class: 'govuk-label' do %>
+      <%= f.label :name, class: 'govuk-label' do %>
         Service name
       <% end %>
-      <%= text_field_tag :name, @service.name, class: 'govuk-input' %>
+      <%= f.text_field :name, class: 'govuk-input' %>
     </div>
     <div class="govuk-form-group">
       <%= label_tag :description, class: 'govuk-label' do %>
         Description
       <% end %>
-      <%= text_area_tag :description, @service.description, rows: 5, class: 'govuk-textarea' %>
+      <%= f.text_area :description, rows: 5, class: 'govuk-textarea' %>
     </div>
     <div class="govuk-form-group">
       <%= label_tag :documentation, class: 'govuk-label' do %>
         Documentation
       <% end %>
-      <%= text_area_tag :documentation, @service.documentation, rows: 5, class: 'govuk-textarea' %>
+      <%= f.text_area :documentation, rows: 5, class: 'govuk-textarea' %>
+    </div>
+    <div class="govuk-form-group">
+      <%= label_tag :teams, class: 'govuk-label' do %>
+        Teams
+      <% end %>
+      <%= f.collection_check_boxes(:team_ids, @teams, :id, :name) do |b| %>
+        <div class="govuk-checkboxes__item">
+          <%= b.check_box class: 'govuk-checkboxes__input'%>
+          <%= b.label class: 'govuk-label govuk-checkboxes__label' %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -25,10 +25,10 @@
   Edit service
 </h1>
 
-<%= form_tag service_path(@service), method: :patch do %>
-  <%= render partial: 'form' %>
+<%= form_for @service, method: :patch do |f| %>
+  <%= render partial: 'form', locals: { f: f } %>
 
   <div class="govuk-form-group">
-    <%= submit_tag 'Update service', class: 'govuk-button' %>
+    <%= f.submit 'Update service', class: 'govuk-button' %>
   </div>
 <% end %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to '/', class: 'govuk-breadcrumbs__link' do %>Home<% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to services_path, class: 'govuk-breadcrumbs__link' do %>
+        Services
+      <% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to service_path(@service), class: 'govuk-breadcrumbs__link' do %>
+        <%= @service.name %>
+      <% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to edit_service_path(@service), class: 'govuk-breadcrumbs__link' do %>
+        Edit service
+      <% end %>
+    </li>
+  </ol>
+</div>
+
+<h1 class="govuk-heading-xl">
+  Edit service
+</h1>
+
+<%= form_tag service_path(@service), method: :patch do %>
+  <%= render partial: 'form' %>
+
+  <div class="govuk-form-group">
+    <%= submit_tag 'Update service', class: 'govuk-button' %>
+  </div>
+<% end %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -38,6 +38,7 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Service</th>
+      <th class="govuk-table__header">Teams</th>
       <th class="govuk-table__header">Score</th>
     </tr>
   </thead>
@@ -48,6 +49,9 @@
           <%= link_to service_path(service), class: 'govuk-link' do %>
             <%= service.name %>
           <% end %>
+        </td>
+        <td class="govuk-table__cell">
+            <%= service.teams.length %>
         </td>
         <td class="govuk-table__cell">
             <%= service.score.round(1) %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -50,7 +50,7 @@
           <% end %>
         </td>
         <td class="govuk-table__cell">
-            <%= service.score %>
+            <%= service.score.round(1) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -42,7 +42,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @services.sort_by(&:name).each do |service| %>
+    <% @services.sort_by(&:score).reverse.each do |service| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <%= link_to service_path(service), class: 'govuk-link' do %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,0 +1,58 @@
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to '/', class: 'govuk-breadcrumbs__link' do %>Home<% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to services_path, class: 'govuk-breadcrumbs__link' do %>
+        Services
+      <% end %>
+    </li>
+  </ol>
+</div>
+
+<h1 class="govuk-heading-xl">Services</h1>
+
+<div>
+  <%= link_to new_service_path, class: 'govuk-button' do %>
+    New service
+  <% end %>
+</div>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      How are services scored?
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p>The maxmium score is 5, the minimum score is 0.</p>
+    <p>
+      Score is determined by whether a service has a description and
+      documentation.
+    </p>
+  </div>
+</details>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Service</th>
+      <th class="govuk-table__header">Score</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @services.sort_by(&:name).each do |service| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= link_to service_path(service), class: 'govuk-link' do %>
+            <%= service.name %>
+          <% end %>
+        </td>
+        <td class="govuk-table__cell">
+            <%= service.score %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -28,8 +28,8 @@
   <div class="govuk-details__text">
     <p>The maxmium score is 5, the minimum score is 0.</p>
     <p>
-      Score is determined by whether a service has a description and
-      documentation.
+      To achieve the maximum score, a service must have a description,
+      documentation, and be associated with at least one team.
     </p>
   </div>
 </details>

--- a/app/views/services/new.html.erb
+++ b/app/views/services/new.html.erb
@@ -20,10 +20,10 @@
   New service
 </h1>
 
-<%= form_tag action: :create, method: :post do %>
-  <%= render partial: 'form' %>
+<%= form_for @service, method: :post do |f| %>
+  <%= render partial: 'form', locals: { f: f } %>
 
   <div class="govuk-form-group">
-    <%= submit_tag 'Create service', class: 'govuk-button' %>
+    <%= f.submit 'Create service', class: 'govuk-button' %>
   </div>
 <% end %>

--- a/app/views/services/new.html.erb
+++ b/app/views/services/new.html.erb
@@ -1,0 +1,29 @@
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to '/', class: 'govuk-breadcrumbs__link' do %>Home<% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to services_path, class: 'govuk-breadcrumbs__link' do %>
+        Services
+      <% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to new_service_path, class: 'govuk-breadcrumbs__link' do %>
+        New service
+      <% end %>
+    </li>
+  </ol>
+</div>
+
+<h1 class="govuk-heading-xl">
+  New service
+</h1>
+
+<%= form_tag action: :create, method: :post do %>
+  <%= render partial: 'form' %>
+
+  <div class="govuk-form-group">
+    <%= submit_tag 'Create service', class: 'govuk-button' %>
+  </div>
+<% end %>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -20,7 +20,7 @@
   <%= @service.name %>
 </h1>
 
-<p class="govuk-body">Score: <%= @service.score %></p>
+<p class="govuk-body">Score: <%= @service.score.round(1) %></p>
 
 <% unless @service.description.blank? %>
   <%= @description.html_safe %>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -1,0 +1,37 @@
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to '/', class: 'govuk-breadcrumbs__link' do %>Home<% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to services_path, class: 'govuk-breadcrumbs__link' do %>
+        Services
+      <% end %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to service_path(@service), class: 'govuk-breadcrumbs__link' do %>
+        <%= @service.name %>
+      <% end %>
+    </li>
+  </ol>
+</div>
+
+<h1 class="govuk-heading-xl">
+  <%= @service.name %>
+</h1>
+
+<p class="govuk-body">Score: <%= @service.score %></p>
+
+<% unless @service.description.blank? %>
+  <%= @description.html_safe %>
+<% end %>
+
+<% unless @service.documentation.blank? %>
+  <%= @documentation.html_safe %>
+<% end %>
+
+<div>
+  <%= link_to edit_service_path(@service), class: 'govuk-button' do %>
+    Edit service
+  <% end %>
+</div>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -20,18 +20,44 @@
   <%= @service.name %>
 </h1>
 
-<p class="govuk-body">Score: <%= @service.score.round(1) %></p>
-
-<% unless @service.description.blank? %>
-  <%= @description.html_safe %>
-<% end %>
-
-<% unless @service.documentation.blank? %>
-  <%= @documentation.html_safe %>
-<% end %>
-
 <div>
   <%= link_to edit_service_path(@service), class: 'govuk-button' do %>
     Edit service
   <% end %>
 </div>
+
+<hr class="govuk-section-break govuk-section-break--visible">
+
+<% if @service.teams.empty? %>
+  <p class="govuk-body">
+    <%= @service.name %> is not associated with any teams
+  </p>
+<% else %>
+  <p class="govuk-body">
+    <%= @service.name %> is associated with the following teams:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <% @service.teams.each do |team| %>
+      <li><%= link_to team_path(team), class: 'govuk-link' do %>
+          <%= team.name %>
+      <% end %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<hr class="govuk-section-break govuk-section-break--visible">
+
+<% if @service.description.blank? %>
+  <p class="govuk-body"><%= @service.name %> has no description</p>
+<% else %>
+  <%= @description.html_safe %>
+<% end %>
+
+<hr class="govuk-section-break govuk-section-break--visible">
+
+<% if @service.documentation.blank? %>
+  <p class="govuk-body"><%= @service.name %> has no documentation</p>
+<% else %>
+  <%= @documentation.html_safe %>
+<% end %>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -23,7 +23,8 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Team</th>
-      <th class="govuk-table__header">Calendar count</th>
+      <th class="govuk-table__header">Calendars</th>
+      <th class="govuk-table__header">Services</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -36,6 +37,9 @@
         </td>
         <td class="govuk-table__cell">
           <%= team.calendars.length %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= team.services.length %>
         </td>
       </tr>
     <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -37,7 +37,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
+  <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-l">Calendars</h2>
     <ul class="govuk-list govuk-list--bullet">
       <% @team.calendars.each do |calendar| %>
@@ -49,7 +49,19 @@
       <% end %>
     </ul>
   </div>
-  <div class="govuk-grid-column-one-half">
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-l">Services</h2>
+    <ul class="govuk-list govuk-list--bullet">
+      <% @team.services.each do |service| %>
+        <li>
+          <%= link_to service_path(service), class: 'govuk-link' do %>
+            <%= service.name %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+  <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-l">Team members</h2>
       <ul class="govuk-list govuk-list--bullet">
         <% @team_members.sort.each do |email| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@
 Rails.application.routes.draw do
   root 'pages#home'
 
+  resources :services, only: %i(index show new create edit update)
+
   resources :teams, only: %i(index show new create edit update)
   get 'teams/:id/conflicts',
     as: 'team_conflicts',

--- a/db/migrate/20200629131902_create_services.rb
+++ b/db/migrate/20200629131902_create_services.rb
@@ -1,0 +1,10 @@
+class CreateServices < ActiveRecord::Migration[6.0]
+  def change
+    create_table :services do |t|
+      t.string :name
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200629132755_add_documentation_to_services.rb
+++ b/db/migrate/20200629132755_add_documentation_to_services.rb
@@ -1,0 +1,5 @@
+class AddDocumentationToServices < ActiveRecord::Migration[6.0]
+  def change
+    add_column :services, :documentation, :text
+  end
+end

--- a/db/migrate/20200629135554_add_slug_to_services.rb
+++ b/db/migrate/20200629135554_add_slug_to_services.rb
@@ -1,0 +1,5 @@
+class AddSlugToServices < ActiveRecord::Migration[6.0]
+  def change
+    add_column :services, :slug, :string
+  end
+end

--- a/db/migrate/20200629142842_create_join_table_service_team.rb
+++ b/db/migrate/20200629142842_create_join_table_service_team.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableServiceTeam < ActiveRecord::Migration[6.0]
+  def change
+    create_join_table :services, :teams do |t|
+      t.index [:service_id, :team_id]
+      t.index [:team_id, :service_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_29_135554) do
+ActiveRecord::Schema.define(version: 2020_06_29_142842) do
 
   create_table "annual_leave_events", force: :cascade do |t|
     t.string "email"
@@ -64,6 +64,13 @@ ActiveRecord::Schema.define(version: 2020_06_29_135554) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "documentation"
     t.string "slug"
+  end
+
+  create_table "services_teams", id: false, force: :cascade do |t|
+    t.integer "service_id", null: false
+    t.integer "team_id", null: false
+    t.index ["service_id", "team_id"], name: "index_services_teams_on_service_id_and_team_id"
+    t.index ["team_id", "service_id"], name: "index_services_teams_on_team_id_and_service_id"
   end
 
   create_table "spatial_ref_sys", primary_key: "srid", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_29_132755) do
+ActiveRecord::Schema.define(version: 2020_06_29_135554) do
 
   create_table "annual_leave_events", force: :cascade do |t|
     t.string "email"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2020_06_29_132755) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "documentation"
+    t.string "slug"
   end
 
   create_table "spatial_ref_sys", primary_key: "srid", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_29_131902) do
+ActiveRecord::Schema.define(version: 2020_06_29_132755) do
 
   create_table "annual_leave_events", force: :cascade do |t|
     t.string "email"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 2020_06_29_131902) do
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "documentation"
   end
 
   create_table "spatial_ref_sys", primary_key: "srid", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_150006) do
+ActiveRecord::Schema.define(version: 2020_06_29_131902) do
 
   create_table "annual_leave_events", force: :cascade do |t|
     t.string "email"
@@ -55,6 +55,13 @@ ActiveRecord::Schema.define(version: 2020_06_24_150006) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["team_id"], name: "index_pager_duty_calendars_on_team_id"
+  end
+
+  create_table "services", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "spatial_ref_sys", primary_key: "srid", force: :cascade do |t|

--- a/test/controllers/services_controller_test.rb
+++ b/test/controllers/services_controller_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+require 'helpers/auth_helper'
+
+class ServicesControllerTest < ActionDispatch::IntegrationTest
+  test 'should create a team with name and teams' do
+    name = 'my service'
+    expected_slug = ActiveSupport::Inflector.parameterize(name)
+
+    team1 = Team.create(name: 'my-team')
+    team2 = Team.create(name: 'my-other-team')
+
+    create_test_session_with_fake_auth
+    post services_path, params: { service: {
+      name: name,
+      team_ids: [team1.id, team2.id],
+    }}
+    assert_redirected_to service_path(id: expected_slug)
+
+    service = Service.find_by_name(name)
+    assert_equal service.name, name
+    assert_equal service.teams, [team1, team2]
+  end
+
+  test 'should update a team with name and teams' do
+    name = 'my service'
+    expected_slug = ActiveSupport::Inflector.parameterize(name)
+
+    service = Service.create(name: name)
+    assert_equal service.name, name
+    assert_equal service.teams, []
+
+    team1 = Team.create(name: 'my-team')
+    team2 = Team.create(name: 'my-other-team')
+
+    create_test_session_with_fake_auth
+    patch service_path(service), params: { service: {
+      name: name,
+      team_ids: [team1.id, team2.id],
+    }}
+
+    service = Service.find_by_name(name)
+    assert_equal service.name, name
+    assert_equal service.teams, [team1, team2]
+  end
+end

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -12,4 +12,24 @@ class ServiceTest < ActiveSupport::TestCase
   test 'service can have empty documentation' do
     assert Service.new(name: 'my-service', documentation: '').valid?
   end
+
+  test 'service without documentation or description receives a score of 0' do
+    s = Service.new(
+      name: 'my-sad-service',
+      description: '',
+      documentation: '',
+    )
+
+    assert_equal s.score, 0
+  end
+
+  test 'service with documentation and description receives a score of 5' do
+    s = Service.new(
+      name: 'my-happy-service',
+      description: 'my-happy-service is described',
+      documentation: 'my-happy-service is documented',
+    )
+
+    assert_equal s.score, 5
+  end
 end

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -23,11 +23,14 @@ class ServiceTest < ActiveSupport::TestCase
     assert_equal s.score, 0
   end
 
-  test 'service with documentation and description receives a score of 5' do
+  test 'service with docs and description and team receives a score of 5' do
+    t = Team.new(name: 'my-team')
+
     s = Service.new(
       name: 'my-happy-service',
       description: 'my-happy-service is described',
       documentation: 'my-happy-service is documented',
+      teams: [t],
     )
 
     assert_equal s.score, 5

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -8,4 +8,8 @@ class ServiceTest < ActiveSupport::TestCase
   test 'service can have empty description' do
     assert Service.new(name: 'my-service', description: '').valid?
   end
+
+  test 'service can have empty documentation' do
+    assert Service.new(name: 'my-service', documentation: '').valid?
+  end
 end

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ServiceTest < ActiveSupport::TestCase
+  test 'service has non-empty name' do
+    assert_not Service.new(name: '').valid?
+  end
+
+  test 'service can have empty description' do
+    assert Service.new(name: 'my-service', description: '').valid?
+  end
+end


### PR DESCRIPTION
What
----

Currently we have 2 main models (teams and calendars) where a team has many calendars. This is good for scheduling, but it doesn't give that much information about which team manages which thing.

At GDS, we don't have a canonical list of what we run, and which teams are associated with $thing.

This PR adds a service model such that:

- a service has a name
- a service has documentation and description fields which are markdown
- a service has and belongs to many teams
- a service is scored based on documentation, description, and team association being present

This is still a bit nascent so I might revert some functionality later.

We have a few "service" shaped things:

- GOV.UK Notify is a good example of a atomised service, associated with a single team
- GOV.UK Verify DCS is good example of a service associated with multiple teams
- Multi-tenant Concourse is a good example of a service that has no logical owner just by the name
- Performance platform is a good example of a service that has got passed buck-passed betwen teams multiple times

Screenshot
----

![image](https://user-images.githubusercontent.com/1482692/86033174-6e4da400-ba30-11ea-9989-02566d16ca8d.png)

Future
----

- A service can be reviewed by someone, like GDS Way pages are
- A service can be connected to PagerDuty / StatusPage /  Pingdom more formally than markdown links
- A service-team relationship could have a type (eg `supports`, `uses`) if we wanted to go more graph-ey

