### PR TITLE
reject non http-looking pagerduty urls

### DIFF
--- a/app/models/pager_duty_calendar.rb
+++ b/app/models/pager_duty_calendar.rb
@@ -17,6 +17,12 @@ class PagerDutyCalendar < ApplicationRecord
             presence: true,
             inclusion: { in: %w[in_hours out_of_hours in_and_out_of_hours] }
 
+  validate :url_is_http
+
+  def url_is_http
+    errors.add(:url, 'expected http(s) calendar address') unless (/^https?:/i).match?(url)
+  end
+
   def events
     calendar = Icalendar::Calendar.parse(
       StringIO.new(Rotas::URL_CACHE.fetch(url))

--- a/test/models/pager_duty_calendar_test.rb
+++ b/test/models/pager_duty_calendar_test.rb
@@ -18,6 +18,15 @@ class PagerDutyCalendarTest < ActiveSupport::TestCase
     ).valid?
   end
 
+  test 'calendar must reject webcal urls' do
+    assert_not PagerDutyCalendar.new(
+      name: 'calendar',
+      team: @stub_team,
+      url:  'webcal://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA',
+      clock_type: 'out_of_hours',
+    ).valid?
+  end
+
   test 'calendar must have valid clock type' do
     assert_not PagerDutyCalendar.new(
       name: 'calendar',


### PR DESCRIPTION
pagerduty calendar urls with bad protocol get stuck fetching forever and
end up blocking the application while it waits for the url to return
successfully and populate the cache.

rather than fix the problem, this puts a plaster over it by rejecting
non-http(s) urls at time of creation

:warning: untested as I couldn't get some of the deps installed