### PR TITLE
Rotas passes linter

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,7 +27,12 @@ jobs:
       uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
       with:
         ruby-version: 2.7.1
+
     - name: Install dependencies
       run: bundle install
+
     - name: Run tests
       run: bundle exec rake
+
+    - name: Lint
+      run: bundle exec rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
@@ -30,6 +32,16 @@ jobs:
 
     - name: Install dependencies
       run: bundle install
+
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.14.0
+
+    - name: Install node deps
+      run: |
+        npm install -g yarn
+        yarn install
 
     - name: Run tests
       run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,33 @@
-Layout/MultilineMethodCallIndentation:
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rspec.yml
+
+inherit_mode:
+  merge:
+    - Exclude
+
+Layout/ArgumentAlignment:
   Enabled: false
-Style/MultilineBlockChain:
+Layout/HeredocIndentation:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Naming/MethodParameterName:
+  AllowedNames:
+    - ca
+    - id
+    - sg
+    - tf
+
+RSpec/DescribedClass:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: false
+Style/NumericPredicate:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,8 @@ Rake/MethodDefinitionInTask:
 RSpec/DescribedClass:
   Enabled: false
 
+Style/EachWithObject:
+  Enabled: false
 Style/HashEachMethods:
   Enabled: false
 Style/NumericPredicate:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ Layout/HeredocIndentation:
   Enabled: false
 Layout/HashAlignment:
   Enabled: false
+Layout/MultilineArrayLineBreaks:
+  Enabled: false
 
 Naming/HeredocDelimiterNaming:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Naming/MethodParameterName:
     - sg
     - tf
 
+Rake/MethodDefinitionInTask:
+  Enabled: false
+
 RSpec/DescribedClass:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,28 +42,28 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem "web-console", ">= 3.3.0"
   gem "listen", "~> 3.2"
+  gem "web-console", ">= 3.3.0"
 end
 
 group :test do
   gem "capybara", ">= 2.15", "< 4.0"
-  gem "webdrivers"
   gem "rubocop-govuk"
+  gem "webdrivers"
 end
 
 group :production do
-  gem "prometheus-client", "~> 2.1"
   gem "pg"
+  gem "prometheus-client", "~> 2.1"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+gem "activeadmin"
+gem "cf-app-utils"
+gem "friendly_id"
 gem "http"
 gem "icalendar"
-gem "cf-app-utils"
 gem "redcarpet"
-gem "friendly_id"
 gem "ruby-graphviz"
-gem "activeadmin"

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "sprockets-rails"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "pry"
   # Use sqlite3 as the database for Active Record
   gem "sqlite3", "~> 1.4"
@@ -58,7 +58,7 @@ group :production do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 gem "activeadmin"
 gem "cf-app-utils"

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ end
 group :test do
   gem 'capybara', '>= 2.15', '< 4.0'
   gem 'webdrivers'
-  gem 'govuk-lint'
+  gem 'rubocop-govuk'
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,23 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby "2.7.1"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.0'
+gem "rails", "~> 6.0"
 # Use Puma as the app server
-gem 'puma', '~> 4.3'
+gem "puma", "~> 4.3"
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5'
+gem "sass-rails", "~> 5"
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem "uglifier", ">= 1.3.0"
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.10'
+gem "jbuilder", "~> 2.10"
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
@@ -30,40 +30,40 @@ gem 'jbuilder', '~> 2.10'
 # gem 'capistrano-rails', group: :development
 
 # for SRI
-gem 'sprockets-rails'
+gem "sprockets-rails"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'pry'
+  gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "pry"
   # Use sqlite3 as the database for Active Record
-  gem 'sqlite3', '~> 1.4'
+  gem "sqlite3", "~> 1.4"
 end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '~> 3.2'
+  gem "web-console", ">= 3.3.0"
+  gem "listen", "~> 3.2"
 end
 
 group :test do
-  gem 'capybara', '>= 2.15', '< 4.0'
-  gem 'webdrivers'
-  gem 'rubocop-govuk'
+  gem "capybara", ">= 2.15", "< 4.0"
+  gem "webdrivers"
+  gem "rubocop-govuk"
 end
 
 group :production do
-  gem 'prometheus-client', '~> 2.1'
-  gem 'pg'
+  gem "prometheus-client", "~> 2.1"
+  gem "pg"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'http'
-gem 'icalendar'
-gem 'cf-app-utils'
-gem 'redcarpet'
-gem 'friendly_id'
-gem 'ruby-graphviz'
-gem 'activeadmin'
+gem "http"
+gem "icalendar"
+gem "cf-app-utils"
+gem "redcarpet"
+gem "friendly_id"
+gem "ruby-graphviz"
+gem "activeadmin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,11 +103,6 @@ GEM
       activerecord (>= 4.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
@@ -168,7 +163,7 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.2)
-    parser (2.7.1.4)
+    parser (2.7.1.5)
       ast (~> 2.4.1)
     pg (1.2.3)
     polyamorous (2.3.2)
@@ -225,23 +220,30 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
-    rubocop (0.86.0)
+    rubocop (0.87.1)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.7)
       rexml
-      rubocop-ast (>= 0.0.3, < 1.0)
+      rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.0.3)
-      parser (>= 2.7.0.1)
+    rubocop-ast (0.7.1)
+      parser (>= 2.7.1.5)
+    rubocop-govuk (3.17.0)
+      rubocop (= 0.87.1)
+      rubocop-rails (= 2.6.0)
+      rubocop-rake (= 0.5.1)
+      rubocop-rspec (= 1.42.0)
     rubocop-rails (2.6.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.82.0)
-    rubocop-rspec (1.40.0)
-      rubocop (>= 0.68.1)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (1.42.0)
+      rubocop (>= 0.87.0)
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.10.1)
@@ -265,8 +267,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -317,7 +317,6 @@ DEPENDENCIES
   capybara (>= 2.15, < 4.0)
   cf-app-utils
   friendly_id
-  govuk-lint
   http
   icalendar
   jbuilder (~> 2.10)
@@ -328,6 +327,7 @@ DEPENDENCIES
   puma (~> 4.3)
   rails (~> 6.0)
   redcarpet
+  rubocop-govuk
   ruby-graphviz
   sass-rails (~> 5)
   sprockets-rails

--- a/Rakefile
+++ b/Rakefile
@@ -5,5 +5,7 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
+desc "Lint ruby and sass"
 task spec: ["lint:ruby", "lint:sass"]
+
 task default: [:spec]

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks
 
-task spec: ['lint:ruby', 'lint:sass']
+task spec: ["lint:ruby", "lint:sass"]
 task default: [:spec]

--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,3 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
-
-desc "Lint ruby and sass"
-task spec: ["lint:ruby", "lint:sass"]
-
-task default: [:spec]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
   def name_fmt(email)
     short = email.split(".").first.capitalize
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,6 +54,7 @@ private
 
   def current_user
     return "disable@auth.user" if ENV.fetch("DISABLE_AUTH", nil)
+
     session.fetch(:email, nil)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
 
 private
   def name_fmt(email)
-    short = email.split('.').first.capitalize
+    short = email.split(".").first.capitalize
 
     return short unless email&.casecmp(current_user)&.zero?
 
@@ -23,15 +23,15 @@ private
   end
 
   def email_fmt(email)
-    return email unless email.end_with?('digital.cabinet-office.gov.uk')
+    return email unless email.end_with?("digital.cabinet-office.gov.uk")
 
     short = email
-      .split('@')
-      .first.tr('.', ' ')
-      .gsub(/[0-9]/, '')
-      .split(' ')
+      .split("@")
+      .first.tr(".", " ")
+      .gsub(/[0-9]/, "")
+      .split(" ")
       .map(&:capitalize)
-      .join(' ')
+      .join(" ")
 
     return short unless email&.casecmp(current_user)&.zero?
 
@@ -39,7 +39,7 @@ private
   end
 
   def people_finder_url(email)
-    slug = email.split('@').first.downcase.tr('.', '-')
+    slug = email.split("@").first.downcase.tr(".", "-")
     "https://peoplefinder.cabinetoffice.gov.uk/people/#{slug}"
   end
 
@@ -52,12 +52,12 @@ private
   end
 
   def current_user
-    return 'disable@auth.user' if ENV.fetch('DISABLE_AUTH', nil)
+    return "disable@auth.user" if ENV.fetch("DISABLE_AUTH", nil)
     session.fetch(:email, nil)
   end
 
   def maybe_expire_session
-    return if ENV.fetch('DISABLE_AUTH', nil)
+    return if ENV.fetch("DISABLE_AUTH", nil)
 
     timestamp           = session.fetch(:timestamp, Time.new(0))
     oldest_session_time = Time.now - 30.minutes
@@ -65,10 +65,10 @@ private
   end
 
   def maybe_redirect_if_not_signed_in
-    return if ENV.fetch('DISABLE_AUTH', nil)
+    return if ENV.fetch("DISABLE_AUTH", nil)
     return if current_user
 
-    if request.method == 'GET'
+    if request.method == "GET"
       session[:redirect_path] = request.fullpath
     end
 

--- a/app/controllers/icalendars_controller.rb
+++ b/app/controllers/icalendars_controller.rb
@@ -8,7 +8,7 @@ class IcalendarsController < ApplicationController
     fragment = params[:id]
     email    = Rotas::CalendarUrl.email_from_url_fragment(fragment)
 
-    raise ActionController::RoutingError.new('Not Found') if email.blank?
+    raise ActionController::RoutingError.new("Not Found") if email.blank?
 
     calendar = Icalendar::Calendar.new
 
@@ -34,11 +34,11 @@ class IcalendarsController < ApplicationController
         calendar.event do |event|
           event.dtstart = e.start_date
           event.dtend   = e.end_date
-          event.summary = 'Annual leave'
-          event.description = 'Annual leave'
+          event.summary = "Annual leave"
+          event.description = "Annual leave"
         end
       end
 
-    send_data calendar.to_ical, filename: 'rotas.ics', type: 'text/calendar', disposition: 'attachment'
+    send_data calendar.to_ical, filename: "rotas.ics", type: "text/calendar", disposition: "attachment"
   end
 end

--- a/app/controllers/icalendars_controller.rb
+++ b/app/controllers/icalendars_controller.rb
@@ -1,8 +1,8 @@
 class IcalendarsController < ApplicationController
   skip_before_action :maybe_redirect_if_not_signed_in,
-                     only: %i(show)
+                     only: %i[show]
   skip_before_action :maybe_expire_session,
-                     only: %i(show)
+                     only: %i[show]
 
   def show
     fragment = params[:id]

--- a/app/controllers/icalendars_controller.rb
+++ b/app/controllers/icalendars_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/RaiseArgs
 class IcalendarsController < ApplicationController
   skip_before_action :maybe_redirect_if_not_signed_in,
                      only: %i[show]
@@ -42,3 +43,4 @@ class IcalendarsController < ApplicationController
     send_data calendar.to_ical, filename: "rotas.ics", type: "text/calendar", disposition: "attachment"
   end
 end
+# rubocop:enable Style/RaiseArgs

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
-require 'tempfile'
-require 'ruby-graphviz'
+require "tempfile"
+require "ruby-graphviz"
 
 class PagesController < ApplicationController
   def home
@@ -17,7 +17,7 @@ class PagesController < ApplicationController
   def org_map
     g = GraphViz.new(:G, type: :digraph)
 
-    node_styles = { shape: :rect, fontname: 'Helvetica-Bold', penwidth: 1.5 }
+    node_styles = { shape: :rect, fontname: "Helvetica-Bold", penwidth: 1.5 }
     edge_styles = { penwidth: 1.5 }
 
     g.subgraph do |c|
@@ -59,7 +59,7 @@ class PagesController < ApplicationController
       end
     end
 
-    tmp = Tempfile.new('org-map-svg')
+    tmp = Tempfile.new("org-map-svg")
     begin
       g.output(svg: tmp.path)
       @org_map_image = tmp.read

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -36,7 +36,7 @@ class ServicesController < ApplicationController
     @service = Service.new(params.require(:service).permit(
       :name,
       :description, :documentation,
-      { team_ids: [] },
+      { team_ids: [] }
     ))
 
     unless @service.valid?
@@ -53,7 +53,7 @@ class ServicesController < ApplicationController
     @service.assign_attributes(params.require(:service).permit(
       :name,
       :description, :documentation,
-      { team_ids: [] },
+      { team_ids: [] }
     ))
 
     unless @service.valid?

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -34,7 +34,7 @@ class ServicesController < ApplicationController
 
   def create
     @service = Service.new(params.require(:service).permit(
-      :name,
+                             :name,
       :description, :documentation,
       { team_ids: [] }
     ))
@@ -51,7 +51,7 @@ class ServicesController < ApplicationController
   def update
     @service = Service.friendly.find(params[:id])
     @service.assign_attributes(params.require(:service).permit(
-      :name,
+                                 :name,
       :description, :documentation,
       { team_ids: [] }
     ))

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -3,11 +3,11 @@ class ServicesController < ApplicationController
     @services = Service.all.sort_by(&:name)
 
     case params[:sort]
-    when 'name'
+    when "name"
       @services = @services.sort_by(&:name)
-    when 'teams'
+    when "teams"
       @services = @services.sort_by { |s| s.teams.length }.reverse
-    when 'score'
+    when "score"
       @services = @services.sort_by(&:score).reverse
     end
   end
@@ -15,10 +15,10 @@ class ServicesController < ApplicationController
   def show
     @service = Service.friendly.find(params[:id])
 
-    description = @service.description || ''
+    description = @service.description || ""
     @description = Rotas::MarkdownRenderer.render(description)
 
-    documentation = @service.documentation || ''
+    documentation = @service.documentation || ""
     @documentation = Rotas::MarkdownRenderer.render(documentation)
   end
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -37,7 +37,7 @@ class ServicesController < ApplicationController
                              :name,
       :description, :documentation,
       { team_ids: [] }
-    ))
+                           ))
 
     unless @service.valid?
       @teams = Team.all
@@ -54,7 +54,7 @@ class ServicesController < ApplicationController
                                  :name,
       :description, :documentation,
       { team_ids: [] }
-    ))
+                               ))
 
     unless @service.valid?
       @teams = Team.all

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,7 +40,7 @@ class SessionsController < ApplicationController
 
     oauth_response = HTTP.post(
       "https://www.googleapis.com/oauth2/v4/token",
-      form: payload
+      form: payload,
     )
     oauth_parsed = JSON.parse(oauth_response.body)
 
@@ -48,7 +48,7 @@ class SessionsController < ApplicationController
     id_token     = oauth_parsed["id_token"]
 
     me_response = HTTP.get(
-      "https://www.googleapis.com/userinfo/v2/me?access_token=#{access_token}"
+      "https://www.googleapis.com/userinfo/v2/me?access_token=#{access_token}",
     )
     me_parsed = JSON.parse(me_response)
     email     = me_parsed["email"]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,7 +35,7 @@ class SessionsController < ApplicationController
       code:          code,
       state:         state,
       redirect_uri:  callback_url,
-      grant_type:    "authorization_code"
+      grant_type:    "authorization_code",
     }
 
     oauth_response = HTTP.post(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,8 @@
 class SessionsController < ApplicationController
   skip_before_action :maybe_redirect_if_not_signed_in,
-                     only: %i(new create callback)
+                     only: %i[new create callback]
   skip_before_action :maybe_expire_session,
-                     only: %i(new create callback)
+                     only: %i[new create callback]
 
   def new; end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,8 +10,8 @@ class SessionsController < ApplicationController
     session[:state] = SecureRandom.hex
 
     query = {
-      scope:         'email',
-      response_type: 'code',
+      scope:         "email",
+      response_type: "code",
       state:         session[:state],
       redirect_uri:  callback_url,
       client_id:     google_client_id,
@@ -35,23 +35,23 @@ class SessionsController < ApplicationController
       code:          code,
       state:         state,
       redirect_uri:  callback_url,
-      grant_type:    'authorization_code'
+      grant_type:    "authorization_code"
     }
 
     oauth_response = HTTP.post(
-      'https://www.googleapis.com/oauth2/v4/token',
+      "https://www.googleapis.com/oauth2/v4/token",
       form: payload
     )
     oauth_parsed = JSON.parse(oauth_response.body)
 
-    access_token = oauth_parsed['access_token']
-    id_token     = oauth_parsed['id_token']
+    access_token = oauth_parsed["access_token"]
+    id_token     = oauth_parsed["id_token"]
 
     me_response = HTTP.get(
       "https://www.googleapis.com/userinfo/v2/me?access_token=#{access_token}"
     )
     me_parsed = JSON.parse(me_response)
-    email     = me_parsed['email']
+    email     = me_parsed["email"]
 
     unless Rotas::Authorisation.email_authorised?(email)
       raise Rotas::Errors::AuthorisationError
@@ -79,25 +79,25 @@ class SessionsController < ApplicationController
 private
 
   def callback_url
-    case ENV['RAILS_ENV']
-    when 'production'
-      'https://rotas.cloudapps.digital/session/callback'
+    case ENV["RAILS_ENV"]
+    when "production"
+      "https://rotas.cloudapps.digital/session/callback"
     else
-      'http://localhost:3000/session/callback'
+      "http://localhost:3000/session/callback"
     end
   end
 
   def google_client_id
-    ENV.fetch('GOOGLE_AUTH_CLIENT_ID') do
+    ENV.fetch("GOOGLE_AUTH_CLIENT_ID") do
       CF::App::Credentials
-        .find_by_service_name('rotas-secrets')['google-client-id']
+        .find_by_service_name("rotas-secrets")["google-client-id"]
     end
   end
 
   def google_client_secret
-    ENV.fetch('GOOGLE_AUTH_CLIENT_SECRET') do
+    ENV.fetch("GOOGLE_AUTH_CLIENT_SECRET") do
       CF::App::Credentials
-        .find_by_service_name('rotas-secrets')['google-client-secret']
+        .find_by_service_name("rotas-secrets")["google-client-secret"]
     end
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -71,7 +71,7 @@ class TeamsController < ApplicationController
 
     @conflicts = Rotas::Conflicts.find(
       annual_leave_events,
-      calendars.map { |c| [c, c.person_day_events.group_by(&:date)] }
+      calendars.map { |c| [c, c.person_day_events.group_by(&:date)] },
     ).reject { |_, c| c.empty? }
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -42,7 +42,7 @@ class TeamsController < ApplicationController
     @team = Team.friendly.find(params[:id])
 
     @events_by_calendar = {}
-    @desc = Rotas::MarkdownRenderer.render(@team.description || '')
+    @desc = Rotas::MarkdownRenderer.render(@team.description || "")
 
     @team.calendars.each do |calendar|
       events = calendar.person_day_events

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
       email: current_user,
       event: {
         message: "Viewed the contact details of #{@email} from PagerDuty",
-      }
+      },
     ).save!
 
     @contact_details = Rotas::PagerDutyApi.contact_details_for_email(@email)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,8 @@ class UsersController < ApplicationController
       .select { |e| e.date >= Date.today }
       .select { |e| e.email.casecmp(@email).zero? }
       .reduce({}) do |acc, e|
-        acc[e.date] ||= Set.new; acc[e.date].add(e.calendar)
+        acc[e.date] ||= Set.new
+        acc[e.date].add(e.calendar)
         acc
       end
 

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -12,7 +12,7 @@ class VersionController < ApplicationController
     render plain: version
   end
 
-  private
+private
 
   def _version
     version = `git rev-parse HEAD`

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -2,8 +2,8 @@
 require "English"
 
 class VersionController < ApplicationController
-  skip_before_action :maybe_redirect_if_not_signed_in, only: %i(version)
-  skip_before_action :maybe_expire_session, only: %i(version)
+  skip_before_action :maybe_redirect_if_not_signed_in, only: %i[version]
+  skip_before_action :maybe_expire_session, only: %i[version]
 
   @@version = nil
 

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -1,5 +1,5 @@
 # rubocop:disable Style/ClassVars
-require 'English'
+require "English"
 
 class VersionController < ApplicationController
   skip_before_action :maybe_redirect_if_not_signed_in, only: %i(version)

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -15,10 +15,11 @@ class VersionController < ApplicationController
 private
 
   def _version
-    version = `git rev-parse HEAD`
     version = `cd "#{Rails.application.root}" && git rev-parse HEAD`
     raise version unless $CHILD_STATUS.success?
 
     @@version = version.chomp
+    @@version
   end
 end
+# rubocop:enable Style/ClassVars

--- a/app/lib/rotas/authorisation.rb
+++ b/app/lib/rotas/authorisation.rb
@@ -1,13 +1,13 @@
 module Rotas::Authorisation
   def self.email_authorised?(email)
-    email.end_with? 'digital.cabinet-office.gov.uk'
+    email.end_with? "digital.cabinet-office.gov.uk"
   end
 
   def self.is_admin?(email)
     case email
-    when 'toby.lornewelch-richards@digital.cabinet-office.gov.uk'
+    when "toby.lornewelch-richards@digital.cabinet-office.gov.uk"
       true
-    when 'philip.potter@digital.cabinet-office.gov.uk'
+    when "philip.potter@digital.cabinet-office.gov.uk"
       true
     else
       false

--- a/app/lib/rotas/calendar_url.rb
+++ b/app/lib/rotas/calendar_url.rb
@@ -16,7 +16,7 @@ module Rotas::CalendarUrl
     salt = Rails.application.config.calendar_url_salt
 
     email, hash = JSON.parse(
-      Base64.urlsafe_decode64(url_fragment)
+      Base64.urlsafe_decode64(url_fragment),
     ).values_at("email", "hash")
 
     hash == Digest::SHA2.new(256).hexdigest("#{salt}:#{email}") ? email : nil

--- a/app/lib/rotas/calendar_url.rb
+++ b/app/lib/rotas/calendar_url.rb
@@ -1,6 +1,6 @@
-require 'base64'
-require 'digest'
-require 'json'
+require "base64"
+require "digest"
+require "json"
 
 module Rotas::CalendarUrl
   def self.generate_url(email)
@@ -17,7 +17,7 @@ module Rotas::CalendarUrl
 
     email, hash = JSON.parse(
       Base64.urlsafe_decode64(url_fragment)
-    ).values_at('email', 'hash')
+    ).values_at("email", "hash")
 
     hash == Digest::SHA2.new(256).hexdigest("#{salt}:#{email}") ? email : nil
   rescue # rubocop:disable Style/RescueStandardError

--- a/app/lib/rotas/conflicts.rb
+++ b/app/lib/rotas/conflicts.rb
@@ -7,7 +7,7 @@ module Rotas::Conflicts
           conflicts_for_calendar(
             annual_leave_emails_by_day(annual_leave_events),
             events_by_date,
-          )
+          ),
         ]
       }
       .to_h

--- a/app/lib/rotas/cookie_names.rb
+++ b/app/lib/rotas/cookie_names.rb
@@ -1,3 +1,3 @@
 module Rotas::CookieNames
-  SESSION_COOKIE_NAME = '_gds_re_rotas_session'.freeze
+  SESSION_COOKIE_NAME = "_gds_re_rotas_session".freeze
 end

--- a/app/lib/rotas/errors/authorisation_error.rb
+++ b/app/lib/rotas/errors/authorisation_error.rb
@@ -1,7 +1,7 @@
 module Rotas::Errors
   class AuthorisationError < Exception # rubocop:disable Lint/InheritException
     def self.message
-      'Authorisation error, are you using a GDS Google account?'
+      "Authorisation error, are you using a GDS Google account?"
     end
   end
 end

--- a/app/lib/rotas/markdown_renderer.rb
+++ b/app/lib/rotas/markdown_renderer.rb
@@ -41,13 +41,13 @@ module Rotas
       tag  = "h#{heading_level}"
       size = case heading_level
              when 1
-               'xl'
+               "xl"
              when 2
-               'l'
+               "l"
              when 3
-               'm'
+               "m"
              else
-               's'
+               "s"
              end
 
       <<~HTML

--- a/app/lib/rotas/pager_duty_api.rb
+++ b/app/lib/rotas/pager_duty_api.rb
@@ -4,7 +4,7 @@ module Rotas::PagerDutyApi
 
     user_response = HTTP
       .headers(default_headers)
-      .get(users_url, params: {query: email})
+      .get(users_url, params: { query: email })
 
     user = JSON.parse(user_response).dig("users").first
 

--- a/app/lib/rotas/pager_duty_api.rb
+++ b/app/lib/rotas/pager_duty_api.rb
@@ -6,7 +6,7 @@ module Rotas::PagerDutyApi
       .headers(default_headers)
       .get(users_url, params: {query: email})
 
-    user = JSON.parse(user_response).dig('users').first
+    user = JSON.parse(user_response).dig("users").first
 
     return nil if user.nil?
 
@@ -18,29 +18,29 @@ module Rotas::PagerDutyApi
 
     contact_methods = JSON
       .parse(contact_methods_response)
-      .dig('contact_methods')
+      .dig("contact_methods")
   end
 
   private
 
   def self.api_url
-    'https://api.pagerduty.com/'
+    "https://api.pagerduty.com/"
   end
 
   def self.default_headers
     {
-      accept: 'application/vnd.pagerduty+json;version=2',
+      accept: "application/vnd.pagerduty+json;version=2",
       authorization: "Token token=#{api_key}",
     }
   end
 
   def self.api_key
-    if ENV.key?('VCAP_SERVICES')
+    if ENV.key?("VCAP_SERVICES")
       CF::App::Credentials
-          .find_by_service_name('rotas-secrets')
-          &.fetch('pagerduty-api-key', nil)
+          .find_by_service_name("rotas-secrets")
+          &.fetch("pagerduty-api-key", nil)
     else
-      ENV.fetch('PAGERDUTY_API_KEY')
+      ENV.fetch("PAGERDUTY_API_KEY")
     end
   end
 end

--- a/app/lib/rotas/pager_duty_api.rb
+++ b/app/lib/rotas/pager_duty_api.rb
@@ -16,12 +16,8 @@ module Rotas::PagerDutyApi
       .headers(default_headers)
       .get(contact_methods_url)
 
-    contact_methods = JSON
-      .parse(contact_methods_response)
-      .dig("contact_methods")
+    JSON.parse(contact_methods_response).dig("contact_methods")
   end
-
-  private
 
   def self.api_url
     "https://api.pagerduty.com/"

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end

--- a/app/models/annual_leave_event.rb
+++ b/app/models/annual_leave_event.rb
@@ -8,7 +8,7 @@ private
 
   def end_date_after_start_date?
     if start_date && end_date && end_date < start_date
-      errors.add :end_date, 'must be equal to, or later than start date'
+      errors.add :end_date, "must be equal to, or later than start date"
     end
   end
 end

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -3,7 +3,7 @@ class AuditEvent < ApplicationRecord
 
   validates_each :event do |record, attr, val|
     if attr == :event && !val.is_a?(Hash) && !val.key?(:message)
-      record.errors.add(attr, 'must include a :message in the event')
+      record.errors.add(attr, "must include a :message in the event")
     end
   end
 

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,6 +1,6 @@
 class Calendar
   def self.find(id)
-    return PagerDutyCalendar.find(id) if id.start_with?('pagerduty')
-    return ManualCalendar.find(id) if id.start_with?('manual')
+    return PagerDutyCalendar.find(id) if id.start_with?("pagerduty")
+    return ManualCalendar.find(id) if id.start_with?("manual")
   end
 end

--- a/app/models/manual_calendar.rb
+++ b/app/models/manual_calendar.rb
@@ -1,7 +1,7 @@
-require 'securerandom'
+require "securerandom"
 
 class ManualCalendar < ApplicationRecord
-  self.primary_key = 'id'
+  self.primary_key = "id"
 
   has_many :manual_calendar_events, class_name: :ManualCalendarEvent
   belongs_to :team

--- a/app/models/manual_calendar_event.rb
+++ b/app/models/manual_calendar_event.rb
@@ -11,7 +11,7 @@ private
 
   def end_date_after_start_date?
     if start_date && end_date && end_date < start_date
-      errors.add :end_date, 'must be equal to, or later than start date'
+      errors.add :end_date, "must be equal to, or later than start date"
     end
   end
 end

--- a/app/models/pager_duty_calendar.rb
+++ b/app/models/pager_duty_calendar.rb
@@ -25,7 +25,7 @@ class PagerDutyCalendar < ApplicationRecord
 
   def events
     calendar = Icalendar::Calendar.parse(
-      StringIO.new(Rotas::URL_CACHE.fetch(url))
+      StringIO.new(Rotas::URL_CACHE.fetch(url)),
     )
 
     calendar

--- a/app/models/pager_duty_calendar.rb
+++ b/app/models/pager_duty_calendar.rb
@@ -20,7 +20,7 @@ class PagerDutyCalendar < ApplicationRecord
   validate :url_is_http
 
   def url_is_http
-    errors.add(:url, "expected http(s) calendar address") unless (/^https?:/i).match?(url)
+    errors.add(:url, "expected http(s) calendar address") unless /^https?:/i.match?(url)
   end
 
   def events

--- a/app/models/pager_duty_calendar.rb
+++ b/app/models/pager_duty_calendar.rb
@@ -1,10 +1,10 @@
-require 'http'
-require 'icalendar'
-require 'securerandom'
-require 'set'
+require "http"
+require "icalendar"
+require "securerandom"
+require "set"
 
 class PagerDutyCalendar < ApplicationRecord
-  self.primary_key = 'id'
+  self.primary_key = "id"
 
   belongs_to :team
 
@@ -20,7 +20,7 @@ class PagerDutyCalendar < ApplicationRecord
   validate :url_is_http
 
   def url_is_http
-    errors.add(:url, 'expected http(s) calendar address') unless (/^https?:/i).match?(url)
+    errors.add(:url, "expected http(s) calendar address") unless (/^https?:/i).match?(url)
   end
 
   def events

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -81,6 +81,7 @@ jobs:
                 bundle exec rake db:create
                 bundle exec rake db:schema:load
                 bundle exec rails test
+                bundle exec rubocop
 
                 bundle exec rake assets:precompile
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,10 +1,10 @@
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
-require 'prometheus/middleware/collector'
-require 'prometheus/middleware/exporter'
-require 'prometheus/client'
-require 'prometheus/client/data_stores/direct_file_store'
+require "rails/all"
+require "prometheus/middleware/collector"
+require "prometheus/middleware/exporter"
+require "prometheus/client"
+require "prometheus/client/data_stores/direct_file_store"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -17,10 +17,10 @@ module GdsRotas
 
     # Add recommended security headers and apply a basic lenient Content Security Policy
     config.action_dispatch.default_headers = {
-      'X-Frame-Options' => 'DENY',
-      'X-XSS-Protection' => '1; mode=block',
-      'X-Content-Type-Options' => 'nosniff',
-      'Content-Security-Policy' => "default-src 'self'; " +
+      "X-Frame-Options" => "DENY",
+      "X-XSS-Protection" => "1; mode=block",
+      "X-Content-Type-Options" => "nosniff",
+      "Content-Security-Policy" => "default-src 'self'; " +
         "font-src 'self' data:; " +
         "img-src 'self' data:; " +
         "object-src 'none'; " +
@@ -37,12 +37,12 @@ module GdsRotas
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     #
-    config.autoload_paths << config.root.join('lib')
+    config.autoload_paths << config.root.join("lib")
 
     config.active_job.queue_adapter = :async
 
     config.middleware.use Prometheus::Middleware::Collector
     config.middleware.use Prometheus::Middleware::Exporter
-    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: 'tmp/metrics')
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: "tmp/metrics")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,15 +20,15 @@ module GdsRotas
       "X-Frame-Options" => "DENY",
       "X-XSS-Protection" => "1; mode=block",
       "X-Content-Type-Options" => "nosniff",
-      "Content-Security-Policy" => "default-src 'self'; " +
-        "font-src 'self' data:; " +
-        "img-src 'self' data:; " +
+      "Content-Security-Policy" => "default-src 'self'; " \
+        "font-src 'self' data:; " \
+        "img-src 'self' data:; " \
         "object-src 'none'; " +
         # the script digests are for the inline script in govuk-frontend/template.njk
         # if the scripts in that file change, or more are added, use a command similar to
         # this to generate the digests:
         # `echo "'sha256-"$(echo -n "document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');" | openssl dgst -sha256 -binary | openssl enc -base64)"'"`
-        "script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; " +
+        "script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; " \
         "style-src 'self' 'unsafe-inline'",
     }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module GdsRotas
         # this to generate the digests:
         # `echo "'sha256-"$(echo -n "document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');" | openssl dgst -sha256 -binary | openssl enc -base64)"'"`
         "script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; " +
-        "style-src 'self' 'unsafe-inline'"
+        "style-src 'self' 'unsafe-inline'",
     }
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,13 +14,13 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -18,7 +18,7 @@ ActiveAdmin.setup do |config|
   config.comments = false
   config.batch_actions = true
 
-  config.filter_attributes = [:encrypted_password, :password, :password_confirmation]
+  config.filter_attributes = %i[encrypted_password password password_confirmation]
   config.localize_format = :long
 end
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,7 +11,7 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
+Rails.application.config.assets.precompile += %w[admin.js admin.css]
 
 # This is to get govuk-frontend images / fonts
 Rails.application.config.assets.paths << Rails.root.join(

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,12 +15,12 @@ Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
 # This is to get govuk-frontend images / fonts
 Rails.application.config.assets.paths << Rails.root.join(
-  "node_modules/govuk-frontend/govuk/assets"
+  "node_modules/govuk-frontend/govuk/assets",
 )
 
 # This is to get govuk-frontend css / js
 Rails.application.config.assets.paths << Rails.root.join(
-  "node_modules/govuk-frontend/govuk"
+  "node_modules/govuk-frontend/govuk",
 )
 
 # Rails needs to know about the file extensions for our fonts

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,12 +1,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
@@ -15,12 +15,12 @@ Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
 # This is to get govuk-frontend images / fonts
 Rails.application.config.assets.paths << Rails.root.join(
-  'node_modules/govuk-frontend/govuk/assets'
+  "node_modules/govuk-frontend/govuk/assets"
 )
 
 # This is to get govuk-frontend css / js
 Rails.application.config.assets.paths << Rails.root.join(
-  'node_modules/govuk-frontend/govuk'
+  "node_modules/govuk-frontend/govuk"
 )
 
 # Rails needs to know about the file extensions for our fonts

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,7 +11,7 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
 
 # This is to get govuk-frontend images / fonts
 Rails.application.config.assets.paths << Rails.root.join(

--- a/config/initializers/calendar_url.rb
+++ b/config/initializers/calendar_url.rb
@@ -1,11 +1,11 @@
-require 'securerandom'
+require "securerandom"
 
-calendar_url_salt = if ENV.key?('VCAP_SERVICES')
+calendar_url_salt = if ENV.key?("VCAP_SERVICES")
                       CF::App::Credentials
-                        .find_by_service_name('rotas-secrets')
-                      &.fetch('calendar-url-salt', nil)
+                        .find_by_service_name("rotas-secrets")
+                      &.fetch("calendar-url-salt", nil)
                     else
-                      ENV.fetch('CALENDAR_URL_SALT', nil)
+                      ENV.fetch("CALENDAR_URL_SALT", nil)
                     end || SecureRandom.base64(32)
 
 Rails.application.config.calendar_url_salt = calendar_url_salt

--- a/config/initializers/database.rb
+++ b/config/initializers/database.rb
@@ -1,9 +1,9 @@
-if ENV['RAILS_ENV'] == 'production' && ! $0.match(/rake/)
-  creds = CF::App::Credentials.find_by_service_name('rotas-db')
+if ENV["RAILS_ENV"] == "production" && ! $0.match(/rake/)
+  creds = CF::App::Credentials.find_by_service_name("rotas-db")
 
   # BODGE
-  ENV['DB_HOST']     = creds['hostname']
-  ENV['DB_PORT']     = creds['port'].to_s
-  ENV['DB_USER']     = creds['username']
-  ENV['DB_PASSWORD'] = creds['password']
+  ENV["DB_HOST"]     = creds["hostname"]
+  ENV["DB_PORT"]     = creds["port"].to_s
+  ENV["DB_USER"]     = creds["username"]
+  ENV["DB_PASSWORD"] = creds["password"]
 end

--- a/config/initializers/database.rb
+++ b/config/initializers/database.rb
@@ -1,4 +1,4 @@
-require 'English'
+require "English"
 
 if ENV["RAILS_ENV"] == "production" && !$PROGRAM_NAME.match(/rake/)
   creds = CF::App::Credentials.find_by_service_name("rotas-db")

--- a/config/initializers/database.rb
+++ b/config/initializers/database.rb
@@ -1,4 +1,6 @@
-if ENV["RAILS_ENV"] == "production" && !$0.match(/rake/)
+require 'English'
+
+if ENV["RAILS_ENV"] == "production" && !$PROGRAM_NAME.match(/rake/)
   creds = CF::App::Credentials.find_by_service_name("rotas-db")
 
   # BODGE

--- a/config/initializers/database.rb
+++ b/config/initializers/database.rb
@@ -1,4 +1,4 @@
-if ENV["RAILS_ENV"] == "production" && ! $0.match(/rake/)
+if ENV["RAILS_ENV"] == "production" && !$0.match(/rake/)
   creds = CF::App::Credentials.find_by_service_name("rotas-db")
 
   # BODGE

--- a/config/initializers/secret_key.rb
+++ b/config/initializers/secret_key.rb
@@ -1,20 +1,20 @@
 random_key   = SecureRandom.base64(128)
 random_token = SecureRandom.base64(128)
 
-secret_key_base = if ENV.key?('VCAP_SERVICES')
+secret_key_base = if ENV.key?("VCAP_SERVICES")
                     CF::App::Credentials
-                      .find_by_service_name('rotas-secrets')
-                      &.fetch('secret-key-base', nil)
+                      .find_by_service_name("rotas-secrets")
+                      &.fetch("secret-key-base", nil)
                   else
-                    ENV.fetch('SECRET_KEY_BASE', nil)
+                    ENV.fetch("SECRET_KEY_BASE", nil)
                   end || random_key
 
-secret_token = if ENV.key?('VCAP_SERVICES')
+secret_token = if ENV.key?("VCAP_SERVICES")
                  CF::App::Credentials
-                   .find_by_service_name('rotas-secrets')
-                   &.fetch('secret-token', nil)
+                   .find_by_service_name("rotas-secrets")
+                   &.fetch("secret-token", nil)
                else
-                 ENV.fetch('SECRET_TOKEN', nil)
+                 ENV.fetch("SECRET_TOKEN", nil)
                end || random_token
 
 Rails.application.secrets.secret_key_base = secret_key_base

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,5 +2,5 @@ Rails.application.config.session_store(
   :cookie_store,
   key: Rotas::CookieNames::SESSION_COOKIE_NAME,
   expire_after: 24.hours,
-  same_site: :lax
+  same_site: :lax,
 )

--- a/config/initializers/url_cache.rb
+++ b/config/initializers/url_cache.rb
@@ -32,7 +32,7 @@ module Rotas
   URL_CACHE = UrlCache.new
 end
 
-if Rails.const_defined? 'Server'
+if Rails.const_defined? "Server"
   PagerDutyCalendar.all.each do |calendar|
     Rails.logger.info "Starting url fetcher job for #{calendar.url}"
     Rotas::URL_CACHE.watch(calendar.url)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,4 +53,3 @@ Rails.application.routes.draw do
     post "test_session_create", to: "test_session#create", as: :test_session_create
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   ActiveAdmin.routes(self)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,33 +6,33 @@ Rails.application.routes.draw do
   get "org-map", controller: :pages, action: :org_map, as: :org_map
   get "version", controller: :version, action: :version, as: :version
 
-  resources :org_units, only: %i(index show), path: "/org-units"
+  resources :org_units, only: %i[index show], path: "/org-units"
 
-  resources :services, only: %i(index show new create edit update)
+  resources :services, only: %i[index show new create edit update]
 
-  resources :teams, only: %i(index show new create edit update)
+  resources :teams, only: %i[index show new create edit update]
   get "teams/:id/conflicts",
     as: "team_conflicts",
     controller: :teams,
     action: :conflicts
 
-  resources :icalendars, only: %i(show), id: /.*/
-  resources :calendars, only: %i(index show new create)
-  resources :manual_calendars, only: %i() do
+  resources :icalendars, only: %i[show], id: /.*/
+  resources :calendars, only: %i[index show new create]
+  resources :manual_calendars, only: %i[] do
     resources :events,
-              only: %i(index new create edit update destroy),
+              only: %i[index new create edit update destroy],
               controller: :manual_calendar_events
   end
-  resources :annual_leave_events, only: %i(index new create edit update destroy)
+  resources :annual_leave_events, only: %i[index new create edit update destroy]
 
-  resources :users, only: %i(show), id: /[^\/]*/
+  resources :users, only: %i[show], id: /[^\/]*/
   get "users/:id/contact-info",
       id: /[^\/]*/,
       controller: :users,
       action: :contact_information,
       as: :user_contact_information
 
-  resource :session, only: %i(new create destroy)
+  resource :session, only: %i[new create destroy]
   get "session/callback",
       controller: :sessions,
       action: :callback,
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
         action: :update,
         as: "pager_duty_calendar"
 
-  if %w(test development).include? Rails.env
+  if %w[test development].include? Rails.env
     post "test_session_create", to: "test_session#create", as: :test_session_create
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,17 +2,17 @@
 Rails.application.routes.draw do
   ActiveAdmin.routes(self)
 
-  root 'pages#home'
-  get 'org-map', controller: :pages, action: :org_map, as: :org_map
-  get 'version', controller: :version, action: :version, as: :version
+  root "pages#home"
+  get "org-map", controller: :pages, action: :org_map, as: :org_map
+  get "version", controller: :version, action: :version, as: :version
 
-  resources :org_units, only: %i(index show), path: '/org-units'
+  resources :org_units, only: %i(index show), path: "/org-units"
 
   resources :services, only: %i(index show new create edit update)
 
   resources :teams, only: %i(index show new create edit update)
-  get 'teams/:id/conflicts',
-    as: 'team_conflicts',
+  get "teams/:id/conflicts",
+    as: "team_conflicts",
     controller: :teams,
     action: :conflicts
 
@@ -26,32 +26,32 @@ Rails.application.routes.draw do
   resources :annual_leave_events, only: %i(index new create edit update destroy)
 
   resources :users, only: %i(show), id: /[^\/]*/
-  get 'users/:id/contact-info',
+  get "users/:id/contact-info",
       id: /[^\/]*/,
       controller: :users,
       action: :contact_information,
       as: :user_contact_information
 
   resource :session, only: %i(new create destroy)
-  get 'session/callback',
+  get "session/callback",
       controller: :sessions,
       action: :callback,
-      as: 'callback_session'
+      as: "callback_session"
 
-  get 'calendars/:id/edit',
+  get "calendars/:id/edit",
       id: /pagerduty:.*/,
       controller: :pager_duty_calendars,
       action: :edit,
-      as: 'edit_pager_duty_calendar'
+      as: "edit_pager_duty_calendar"
 
-  patch 'calendars/:id',
+  patch "calendars/:id",
         id: /pagerduty:.*/,
         controller: :pager_duty_calendars,
         action: :update,
-        as: 'pager_duty_calendar'
+        as: "pager_duty_calendar"
 
   if %w(test development).include? Rails.env
-    post 'test_session_create', to: 'test_session#create', as: :test_session_create
+    post "test_session_create", to: "test_session#create", as: :test_session_create
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/db/migrate/20200629142842_create_join_table_service_team.rb
+++ b/db/migrate/20200629142842_create_join_table_service_team.rb
@@ -1,8 +1,8 @@
 class CreateJoinTableServiceTeam < ActiveRecord::Migration[6.0]
   def change
     create_join_table :services, :teams do |t|
-      t.index [:service_id, :team_id]
-      t.index [:team_id, :service_id]
+      t.index %i[service_id team_id]
+      t.index %i[team_id service_id]
     end
   end
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,28 +1,28 @@
 namespace :lint do
-  desc 'lint ruby files'
+  desc "lint ruby files"
   task :ruby do
-    sh 'govuk-lint-ruby app config lib spec', verbose: false do |ok, _|
+    sh "govuk-lint-ruby app config lib spec", verbose: false do |ok, _|
       if ok
-        green('Ruby linting PASSED')
+        green("Ruby linting PASSED")
       else
-        red('Ruby linting FAILED')
+        red("Ruby linting FAILED")
         exit(1)
       end
     end
   end
 
-  desc 'lint sass files'
+  desc "lint sass files"
   task :sass do
     scss_files = FileList.new do |fl|
-      fl.include('app/assets/stylesheets/*.scss')
-      fl.include('app/assets/stylesheets/*/*.scss')
-      fl.exclude('app/assets/stylesheets/vendor/*.scss')
+      fl.include("app/assets/stylesheets/*.scss")
+      fl.include("app/assets/stylesheets/*/*.scss")
+      fl.exclude("app/assets/stylesheets/vendor/*.scss")
     end
-    sh 'govuk-lint-sass', *scss_files, verbose: false do |ok, _|
+    sh "govuk-lint-sass", *scss_files, verbose: false do |ok, _|
       if ok
-        green('SASS linting PASSED')
+        green("SASS linting PASSED")
       else
-        red('SASS linting FAILED')
+        red("SASS linting FAILED")
         exit(1)
       end
     end
@@ -31,10 +31,10 @@ namespace :lint do
 private
 
   def green(msg)
-    puts ENV['TERM'] ? "#{`tput setaf 2`}#{msg}#{`tput sgr0`}" : msg
+    puts ENV["TERM"] ? "#{`tput setaf 2`}#{msg}#{`tput sgr0`}" : msg
   end
 
   def red(msg)
-    puts ENV['TERM'] ? "#{`tput setaf 1`}#{msg}#{`tput sgr0`}" : msg
+    puts ENV["TERM"] ? "#{`tput setaf 1`}#{msg}#{`tput sgr0`}" : msg
   end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -20,7 +20,7 @@ class ApplicationControllerTest < ActionController::TestCase
       firstname.lastname1@digital.cabinet-office.gov.uk
       firstname.middlenamelastname-lastname@digital.cabinet-office.gov.uk
     ]
-    nices = ["Firstname", "Firstname"]
+    nices = %w[Firstname Firstname]
 
     emails.zip(nices).each do |email, nice|
       assert_equal @controller.send(:name_fmt, email), nice

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,8 +1,8 @@
-require 'test_helper'
+require "test_helper"
 
 # class ApplicationControllerTest < ActionDispatch::IntegrationTest
 class ApplicationControllerTest < ActionController::TestCase
-  test 'people finder links are approximately okay' do
+  test "people finder links are approximately okay" do
     emails = %w[
       firstname.lastname1@digital.cabinet-office.gov.uk
       firstname.middlenamelastname-lastname@digital.cabinet-office.gov.uk
@@ -15,24 +15,24 @@ class ApplicationControllerTest < ActionController::TestCase
     end
   end
 
-  test 'name_fmt works' do
+  test "name_fmt works" do
     emails = %w[
       firstname.lastname1@digital.cabinet-office.gov.uk
       firstname.middlenamelastname-lastname@digital.cabinet-office.gov.uk
     ]
-    nices = ['Firstname', 'Firstname']
+    nices = ["Firstname", "Firstname"]
 
     emails.zip(nices).each do |email, nice|
       assert_equal @controller.send(:name_fmt, email), nice
     end
   end
 
-  test 'email_fmt works' do
+  test "email_fmt works" do
     emails = %w[
       firstname.lastname1@digital.cabinet-office.gov.uk
       firstname.middlenamelastname-lastname@digital.cabinet-office.gov.uk
     ]
-    nices = ['Firstname Lastname', 'Firstname Middlenamelastname-lastname']
+    nices = ["Firstname Lastname", "Firstname Middlenamelastname-lastname"]
 
     emails.zip(nices).each do |email, nice|
       assert_equal @controller.send(:email_fmt, email), nice

--- a/test/controllers/org_units_controller_test.rb
+++ b/test/controllers/org_units_controller_test.rb
@@ -1,18 +1,18 @@
-require 'test_helper'
-require 'helpers/auth_helper'
+require "test_helper"
+require "helpers/auth_helper"
 
 class OrgUnitsControllerTest < ActionDispatch::IntegrationTest
-  test 'should show all org-units' do
+  test "should show all org-units" do
     create_test_session_with_fake_auth
     get org_units_path
     assert_response :success
   end
 
-  test 'should show an org-unit' do
+  test "should show an org-unit" do
     create_test_session_with_fake_auth
-    org_unit = OrgUnit.create(name: 'my-ops-ou')
+    org_unit = OrgUnit.create(name: "my-ops-ou")
     get org_unit_path(org_unit)
     assert_response :success
-    assert_select 'h1', text: 'my-ops-ou'
+    assert_select "h1", text: "my-ops-ou"
   end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,9 +1,9 @@
-require 'test_helper'
-require 'helpers/auth_helper'
-require 'helpers/teams_helper'
+require "test_helper"
+require "helpers/auth_helper"
+require "helpers/teams_helper"
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
-  test 'should not allow access to main page when not logged in' do
+  test "should not allow access to main page when not logged in" do
     get root_path
     assert_redirected_to controller: :sessions, action: :new
   end

--- a/test/controllers/services_controller_test.rb
+++ b/test/controllers/services_controller_test.rb
@@ -1,13 +1,13 @@
-require 'test_helper'
-require 'helpers/auth_helper'
+require "test_helper"
+require "helpers/auth_helper"
 
 class ServicesControllerTest < ActionDispatch::IntegrationTest
-  test 'should create a team with name and teams' do
-    name = 'my service'
+  test "should create a team with name and teams" do
+    name = "my service"
     expected_slug = ActiveSupport::Inflector.parameterize(name)
 
-    team1 = Team.create(name: 'my-team')
-    team2 = Team.create(name: 'my-other-team')
+    team1 = Team.create(name: "my-team")
+    team2 = Team.create(name: "my-other-team")
 
     create_test_session_with_fake_auth
     post services_path, params: { service: {
@@ -21,16 +21,16 @@ class ServicesControllerTest < ActionDispatch::IntegrationTest
     assert_equal service.teams, [team1, team2]
   end
 
-  test 'should update a team with name and teams' do
-    name = 'my service'
+  test "should update a team with name and teams" do
+    name = "my service"
     expected_slug = ActiveSupport::Inflector.parameterize(name)
 
     service = Service.create(name: name)
     assert_equal service.name, name
     assert_equal service.teams, []
 
-    team1 = Team.create(name: 'my-team')
-    team2 = Team.create(name: 'my-other-team')
+    team1 = Team.create(name: "my-team")
+    team2 = Team.create(name: "my-other-team")
 
     create_test_session_with_fake_auth
     patch service_path(service), params: { service: {

--- a/test/controllers/services_controller_test.rb
+++ b/test/controllers/services_controller_test.rb
@@ -13,7 +13,7 @@ class ServicesControllerTest < ActionDispatch::IntegrationTest
     post services_path, params: { service: {
       name: name,
       team_ids: [team1.id, team2.id],
-    }}
+    } }
     assert_redirected_to service_path(id: expected_slug)
 
     service = Service.find_by_name(name)
@@ -36,7 +36,7 @@ class ServicesControllerTest < ActionDispatch::IntegrationTest
     patch service_path(service), params: { service: {
       name: name,
       team_ids: [team1.id, team2.id],
-    }}
+    } }
 
     service = Service.find_by_name(name)
     assert_equal service.name, name

--- a/test/controllers/services_controller_test.rb
+++ b/test/controllers/services_controller_test.rb
@@ -23,7 +23,6 @@ class ServicesControllerTest < ActionDispatch::IntegrationTest
 
   test "should update a team with name and teams" do
     name = "my service"
-    expected_slug = ActiveSupport::Inflector.parameterize(name)
 
     service = Service.create(name: name)
     assert_equal service.name, name

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,23 +1,23 @@
-require 'test_helper'
+require "test_helper"
 
 class SessionsControllerTest < ActionDispatch::IntegrationTest
-  test 'should get new session page' do
+  test "should get new session page" do
     get new_session_path
     assert_response :success
   end
 
-  test 'should not get teams page when not signed in' do
+  test "should not get teams page when not signed in" do
     get teams_path
     assert_redirected_to controller: :sessions, action: :new
   end
 
-  test 'should not get calendars page when not signed in' do
+  test "should not get calendars page when not signed in" do
     get calendars_path
     assert_redirected_to controller: :sessions, action: :new
   end
 
-  test 'should not a user page when not signed in' do
-    get user_path('test')
+  test "should not a user page when not signed in" do
+    get user_path("test")
     assert_redirected_to controller: :sessions, action: :new
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,47 +1,47 @@
-require 'test_helper'
-require 'minitest/mock'
-require 'helpers/auth_helper'
-require 'helpers/teams_helper'
+require "test_helper"
+require "minitest/mock"
+require "helpers/auth_helper"
+require "helpers/teams_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
-  test 'should log an audit event and show contact details correctly' do
+  test "should log an audit event and show contact details correctly" do
     Rotas::PagerDutyApi.stub(
       :contact_details_for_email, [
         {
-          'type'    => 'email_contact_method',
-          'address' => 'email-address',
-          'label'   => 'Work email',
+          "type"    => "email_contact_method",
+          "address" => "email-address",
+          "label"   => "Work email",
         },
         {
-          'type'    => 'email_contact_method',
-          'address' => 'email2-address',
-          'label'   => 'Home email',
+          "type"    => "email_contact_method",
+          "address" => "email2-address",
+          "label"   => "Home email",
         },
         {
-          'type'    => 'phone_contact_method',
-          'address' => 'phone-address',
-          'label'   => 'Work phone',
+          "type"    => "phone_contact_method",
+          "address" => "phone-address",
+          "label"   => "Work phone",
         },
         {
-          'type'    => 'phone_contact_method',
-          'address' => 'phone2-address',
-          'label'   => 'Home phone',
+          "type"    => "phone_contact_method",
+          "address" => "phone2-address",
+          "label"   => "Home phone",
         },
         {
-          'type'    => 'sms_contact_method',
-          'address' => 'sms-address',
-          'label'   => 'Work SMS',
+          "type"    => "sms_contact_method",
+          "address" => "sms-address",
+          "label"   => "Work SMS",
         },
         {
-          'type'    => 'push_notification_contact_method',
-          'address' => 'push-address',
-          'label'   => 'Work push',
+          "type"    => "push_notification_contact_method",
+          "address" => "push-address",
+          "label"   => "Work push",
         },
       ]
     ) do
       create_test_session_with_fake_auth
 
-      email = 'log-an-audit-event@test'
+      email = "log-an-audit-event@test"
 
       get user_contact_information_path(id: email)
       assert_response :success
@@ -53,36 +53,36 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_equal audit_event.event[:message],
                    "Viewed the contact details of #{email} from PagerDuty"
 
-      assert_select 'th', /Email/
-      assert_select 'td', /email-address/
-      assert_select 'td', /Work email/
-      assert_select 'td', /email2-address/
-      assert_select 'td', /Home email/
+      assert_select "th", /Email/
+      assert_select "td", /email-address/
+      assert_select "td", /Work email/
+      assert_select "td", /email2-address/
+      assert_select "td", /Home email/
 
-      assert_select 'th', /Phone/
-      assert_select 'td', /phone-address/
-      assert_select 'td', /Work phone/
-      assert_select 'td', /phone2-address/
-      assert_select 'td', /Home phone/
+      assert_select "th", /Phone/
+      assert_select "td", /phone-address/
+      assert_select "td", /Work phone/
+      assert_select "td", /phone2-address/
+      assert_select "td", /Home phone/
 
-      assert_select 'th', /SMS/
-      assert_select 'td', /sms-address/
-      assert_select 'td', /Work SMS/
+      assert_select "th", /SMS/
+      assert_select "td", /sms-address/
+      assert_select "td", /Work SMS/
 
-      assert_select 'th', /Push/
-      assert_select 'td', {
+      assert_select "th", /Push/
+      assert_select "td", {
         text: /push-address/,
         count: 0,
-      }, 'Hide push address as it is meaningless'
-      assert_select 'td', /Work push/
+      }, "Hide push address as it is meaningless"
+      assert_select "td", /Work push/
     end
   end
 
-  test 'should log an audit event and show a helpful msg when no details' do
+  test "should log an audit event and show a helpful msg when no details" do
     Rotas::PagerDutyApi.stub(:contact_details_for_email, nil) do
       create_test_session_with_fake_auth
 
-      email = 'log-an-audit-event-404@test'
+      email = "log-an-audit-event-404@test"
 
       get user_contact_information_path(id: email)
       assert_response :success
@@ -94,7 +94,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_equal audit_event.event[:message],
                    "Viewed the contact details of #{email} from PagerDuty"
 
-      assert_select 'p', /There are no contact details in PagerDuty/
+      assert_select "p", /There are no contact details in PagerDuty/
     end
   end
 end

--- a/test/controllers/version_controller_test.rb
+++ b/test/controllers/version_controller_test.rb
@@ -1,5 +1,5 @@
-require 'English'
-require 'test_helper'
+require "English"
+require "test_helper"
 
 class VersionControllerTest < ActionDispatch::IntegrationTest
   test "should show the git sha" do

--- a/test/controllers/version_controller_test.rb
+++ b/test/controllers/version_controller_test.rb
@@ -10,5 +10,4 @@ class VersionControllerTest < ActionDispatch::IntegrationTest
 
     assert_match git_sha, response.body
   end
-
 end

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -1,5 +1,5 @@
 def create_test_session_with_fake_auth
-    post test_session_create_path
+  post test_session_create_path
 end
 
 def test_session_email

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -3,5 +3,5 @@ def create_test_session_with_fake_auth
 end
 
 def test_session_email
-  'emailyemail.emailyemail@digital.cabinet-office.gov.uk'
+  "emailyemail.emailyemail@digital.cabinet-office.gov.uk"
 end

--- a/test/helpers/teams_helper.rb
+++ b/test/helpers/teams_helper.rb
@@ -1,3 +1,3 @@
 def create_team(name, description)
-    post teams_path, params: { name: name, description: description }
+  post teams_path, params: { name: name, description: description }
 end

--- a/test/integration/cookies_test.rb
+++ b/test/integration/cookies_test.rb
@@ -1,6 +1,6 @@
-require 'test_helper'
-require 'helpers/auth_helper'
-require 'time'
+require "test_helper"
+require "helpers/auth_helper"
+require "time"
 
 class CookiesTest < ActionDispatch::IntegrationTest
   test "cookies are secure" do

--- a/test/integration/cookies_test.rb
+++ b/test/integration/cookies_test.rb
@@ -12,11 +12,11 @@ class CookiesTest < ActionDispatch::IntegrationTest
     assert_not_nil cookies[Rotas::CookieNames::SESSION_COOKIE_NAME]
 
     # need to use response.headers to verify that SameSite and expiry are set :/
-    assert_match /^#{Rotas::CookieNames::SESSION_COOKIE_NAME}=.+$/, response.headers["Set-Cookie"]
+    assert_match(/^#{Rotas::CookieNames::SESSION_COOKIE_NAME}=.+$/, response.headers["Set-Cookie"])
 
-    assert_match /SameSite=Lax/, response.headers["Set-Cookie"], "SameSite=Strict not enabled for this app!"
+    assert_match(/SameSite=Lax/, response.headers["Set-Cookie"], "SameSite=Strict not enabled for this app!")
 
-    assert_match /HttpOnly/, response.headers["Set-Cookie"], "HttpOnly not enabled for this app!"
+    assert_match(/HttpOnly/, response.headers["Set-Cookie"], "HttpOnly not enabled for this app!")
 
     cookie_expires = response.headers["Set-Cookie"].match(/^.+expires=([^;]+);.+$/)[1]
     assert_not_nil cookie_expires, "Expiry not found in Set-Cookie"

--- a/test/integration/pager_duty_calendars_test.rb
+++ b/test/integration/pager_duty_calendars_test.rb
@@ -1,13 +1,13 @@
-require 'test_helper'
-require 'helpers/auth_helper'
-require 'time'
+require "test_helper"
+require "helpers/auth_helper"
+require "time"
 
 class PagerDutyCalendarsTest < ActionDispatch::IntegrationTest
   setup do
-    @team     = Team.create(name: 'myteam')
+    @team     = Team.create(name: "myteam")
     @calendar = PagerDutyCalendar.create(
-      name: 'mypdcal',
-      url:  'https://example.com',
+      name: "mypdcal",
+      url:  "https://example.com",
       team: @team,
       clock_type: :in_hours,
     )
@@ -27,15 +27,15 @@ class PagerDutyCalendarsTest < ActionDispatch::IntegrationTest
     patch pager_duty_calendar_path(@calendar.id),
           params: {
             id:   @calendar.id,
-            name: 'mypdcalchanged',
-            url:  'https://gov.uk',
+            name: "mypdcalchanged",
+            url:  "https://gov.uk",
           }
     assert_response :redirect
     follow_redirect!
     assert_response :success
 
     calendar = PagerDutyCalendar.find(@calendar.id)
-    assert_equal calendar.name, 'mypdcalchanged'
-    assert_equal calendar.url,  'https://gov.uk'
+    assert_equal calendar.name, "mypdcalchanged"
+    assert_equal calendar.url,  "https://gov.uk"
   end
 end

--- a/test/lib/authorisation_test.rb
+++ b/test/lib/authorisation_test.rb
@@ -1,19 +1,19 @@
-require 'test_helper'
+require "test_helper"
 
 class RotasAuthorisationTest < ActiveSupport::TestCase
-  test 'valid' do
-    assert Rotas::Authorisation.email_authorised? ('valid@digital.cabinet-office.gov.uk')
+  test "valid" do
+    assert Rotas::Authorisation.email_authorised? ("valid@digital.cabinet-office.gov.uk")
   end
 
-  test 'invalid gov' do
-    assert_not Rotas::Authorisation.email_authorised? ('invalid@culture.gov.uk')
+  test "invalid gov" do
+    assert_not Rotas::Authorisation.email_authorised? ("invalid@culture.gov.uk")
   end
 
-  test 'invalid nongov' do
-    assert_not Rotas::Authorisation.email_authorised? ('someone@gmail.com')
+  test "invalid nongov" do
+    assert_not Rotas::Authorisation.email_authorised? ("someone@gmail.com")
   end
 
-  test 'invalid random' do
-    assert_not Rotas::Authorisation.email_authorised? ('asdf')
+  test "invalid random" do
+    assert_not Rotas::Authorisation.email_authorised? ("asdf")
   end
 end

--- a/test/lib/authorisation_test.rb
+++ b/test/lib/authorisation_test.rb
@@ -2,18 +2,18 @@ require "test_helper"
 
 class RotasAuthorisationTest < ActiveSupport::TestCase
   test "valid" do
-    assert Rotas::Authorisation.email_authorised? ("valid@digital.cabinet-office.gov.uk")
+    assert Rotas::Authorisation.email_authorised?("valid@digital.cabinet-office.gov.uk")
   end
 
   test "invalid gov" do
-    assert_not Rotas::Authorisation.email_authorised? ("invalid@culture.gov.uk")
+    assert_not Rotas::Authorisation.email_authorised?("invalid@culture.gov.uk")
   end
 
   test "invalid nongov" do
-    assert_not Rotas::Authorisation.email_authorised? ("someone@gmail.com")
+    assert_not Rotas::Authorisation.email_authorised?("someone@gmail.com")
   end
 
   test "invalid random" do
-    assert_not Rotas::Authorisation.email_authorised? ("asdf")
+    assert_not Rotas::Authorisation.email_authorised?("asdf")
   end
 end

--- a/test/lib/calendar_test.rb
+++ b/test/lib/calendar_test.rb
@@ -3,7 +3,6 @@ require "minitest/mock"
 
 class RotasCalendarTest < ActiveSupport::TestCase
   test "calendar shows current team members only" do
-
     class Calendar
       include Rotas::Calendar
 

--- a/test/lib/calendar_test.rb
+++ b/test/lib/calendar_test.rb
@@ -1,16 +1,16 @@
-require 'test_helper'
-require 'minitest/mock'
+require "test_helper"
+require "minitest/mock"
 
 class RotasCalendarTest < ActiveSupport::TestCase
-  test 'calendar shows current team members only' do
+  test "calendar shows current team members only" do
 
     class Calendar
       include Rotas::Calendar
 
       def person_day_events
         [
-          Rotas::PersonDayEvent.new(nil, 'notcurrent', Date.today - 3),
-          Rotas::PersonDayEvent.new(nil, 'current', Date.today + 1),
+          Rotas::PersonDayEvent.new(nil, "notcurrent", Date.today - 3),
+          Rotas::PersonDayEvent.new(nil, "current", Date.today + 1),
         ]
       end
     end
@@ -20,6 +20,6 @@ class RotasCalendarTest < ActiveSupport::TestCase
     members = calendar.members
 
     assert_equal members.length, 1
-    assert_equal members.first, 'current'
+    assert_equal members.first, "current"
   end
 end

--- a/test/lib/calendar_url_test.rb
+++ b/test/lib/calendar_url_test.rb
@@ -1,19 +1,19 @@
-require 'test_helper'
+require "test_helper"
 
 class RotasCalendarUrlTest < ActiveSupport::TestCase
-  test 'valid_url_is_valid' do
+  test "valid_url_is_valid" do
     url_fragment = Rotas::CalendarUrl.generate_url(
-      'skimmed.milk@digital.cabinet-office.gov.uk'
+      "skimmed.milk@digital.cabinet-office.gov.uk"
     )
 
     validated_email = Rotas::CalendarUrl.email_from_url_fragment(
       url_fragment
     )
-    assert_equal validated_email, 'skimmed.milk@digital.cabinet-office.gov.uk'
+    assert_equal validated_email, "skimmed.milk@digital.cabinet-office.gov.uk"
   end
 
-  test 'invalid_url_is_invalid' do
-    bogus_url_fragment = 'skimmed+milk='
+  test "invalid_url_is_invalid" do
+    bogus_url_fragment = "skimmed+milk="
 
     assert Rotas::CalendarUrl.email_from_url_fragment(
       bogus_url_fragment

--- a/test/lib/calendar_url_test.rb
+++ b/test/lib/calendar_url_test.rb
@@ -3,11 +3,11 @@ require "test_helper"
 class RotasCalendarUrlTest < ActiveSupport::TestCase
   test "valid_url_is_valid" do
     url_fragment = Rotas::CalendarUrl.generate_url(
-      "skimmed.milk@digital.cabinet-office.gov.uk"
+      "skimmed.milk@digital.cabinet-office.gov.uk",
     )
 
     validated_email = Rotas::CalendarUrl.email_from_url_fragment(
-      url_fragment
+      url_fragment,
     )
     assert_equal validated_email, "skimmed.milk@digital.cabinet-office.gov.uk"
   end
@@ -16,7 +16,7 @@ class RotasCalendarUrlTest < ActiveSupport::TestCase
     bogus_url_fragment = "skimmed+milk="
 
     assert Rotas::CalendarUrl.email_from_url_fragment(
-      bogus_url_fragment
+      bogus_url_fragment,
     ).nil?
   end
 end

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -37,15 +37,15 @@ class RotasConflictTest < ActiveSupport::TestCase
 
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
       {
-        Date.parse("2018-01-01") => %w[email]
+        Date.parse("2018-01-01") => %w[email],
       },
       {
         Date.parse("2018-01-01") => [
           Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-01")),
-        ]
+        ],
       },
     ), {
-      Date.parse("2018-01-01") => %w[email]
+      Date.parse("2018-01-01") => %w[email],
     }
 
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
@@ -89,11 +89,11 @@ class RotasConflictTest < ActiveSupport::TestCase
         "cal" => {
           Date.parse("2018-01-01") => [
             Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-01")),
-          ]
+          ],
         },
      }), {
       "cal" => {
-        Date.parse("2018-01-01") => %w[email]
+        Date.parse("2018-01-01") => %w[email],
       },
     }
   end

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -43,7 +43,7 @@ class RotasConflictTest < ActiveSupport::TestCase
         Date.parse("2018-01-01") => [
           Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-01")),
         ]
-      }
+      },
     ), {
       Date.parse("2018-01-01") => %w[email]
     }
@@ -65,7 +65,7 @@ class RotasConflictTest < ActiveSupport::TestCase
         Date.parse("2018-01-03") => [
           Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-03")),
         ],
-      }
+      },
     ), {
       Date.parse("2018-01-01") => %w[email],
       Date.parse("2018-01-02") => %w[another],

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -91,10 +91,10 @@ class RotasConflictTest < ActiveSupport::TestCase
             Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-01")),
           ],
         },
-     }), {
-      "cal" => {
-        Date.parse("2018-01-01") => %w[email],
-      },
-    }
+      }), {
+        "cal" => {
+          Date.parse("2018-01-01") => %w[email],
+        },
+      }
   end
 end

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -93,9 +93,9 @@ class RotasConflictTest < ActiveSupport::TestCase
         },
       }
 ), {
-        "cal" => {
-          Date.parse("2018-01-01") => %w[email],
-        },
-      }
+  "cal" => {
+    Date.parse("2018-01-01") => %w[email],
+  },
+}
   end
 end

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -9,7 +9,7 @@ class RotasConflictTest < ActiveSupport::TestCase
         end_date: Date.parse("2018-01-01"),
       )
     ]), {
-      Date.parse("2018-01-01") => ["email"],
+      Date.parse("2018-01-01") => %w[email],
     }
 
     assert_equal Rotas::Conflicts.annual_leave_emails_by_day([
@@ -24,8 +24,8 @@ class RotasConflictTest < ActiveSupport::TestCase
         end_date: Date.parse("2018-01-02"),
       )
     ]), {
-      Date.parse("2018-01-01") => ["email"],
-      Date.parse("2018-01-02") => ["email", "another"],
+      Date.parse("2018-01-01") => %w[email],
+      Date.parse("2018-01-02") => %w[email another],
     }
   end
 
@@ -37,7 +37,7 @@ class RotasConflictTest < ActiveSupport::TestCase
 
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
       {
-        Date.parse("2018-01-01") => ["email"]
+        Date.parse("2018-01-01") => %w[email]
       },
       {
         Date.parse("2018-01-01") => [
@@ -45,14 +45,14 @@ class RotasConflictTest < ActiveSupport::TestCase
         ]
       }
     ), {
-      Date.parse("2018-01-01") => ["email"]
+      Date.parse("2018-01-01") => %w[email]
     }
 
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
       {
-        Date.parse("2018-01-01") => ["email"],
-        Date.parse("2018-01-02") => ["another"],
-        Date.parse("2018-01-03") => ["email"],
+        Date.parse("2018-01-01") => %w[email],
+        Date.parse("2018-01-02") => %w[another],
+        Date.parse("2018-01-03") => %w[email],
       },
       {
         Date.parse("2018-01-01") => [
@@ -67,9 +67,9 @@ class RotasConflictTest < ActiveSupport::TestCase
         ],
       }
     ), {
-      Date.parse("2018-01-01") => ["email"],
-      Date.parse("2018-01-02") => ["another"],
-      Date.parse("2018-01-03") => ["email"],
+      Date.parse("2018-01-01") => %w[email],
+      Date.parse("2018-01-02") => %w[another],
+      Date.parse("2018-01-03") => %w[email],
     }
   end
 
@@ -93,7 +93,7 @@ class RotasConflictTest < ActiveSupport::TestCase
         },
      }), {
       "cal" => {
-        Date.parse("2018-01-01") => ["email"]
+        Date.parse("2018-01-01") => %w[email]
       },
     }
   end

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -92,7 +92,7 @@ class RotasConflictTest < ActiveSupport::TestCase
           ],
         },
       }
-), {
+    ), {
   "cal" => {
     Date.parse("2018-01-01") => %w[email],
   },

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -1,35 +1,35 @@
-require 'test_helper'
+require "test_helper"
 
 class RotasConflictTest < ActiveSupport::TestCase
-  test 'annual_leave_emails_by_day' do
+  test "annual_leave_emails_by_day" do
     assert_equal Rotas::Conflicts.annual_leave_emails_by_day([
       AnnualLeaveEvent.new(
-        email: 'email',
-        start_date: Date.parse('2018-01-01'),
-        end_date: Date.parse('2018-01-01'),
+        email: "email",
+        start_date: Date.parse("2018-01-01"),
+        end_date: Date.parse("2018-01-01"),
       )
     ]), {
-      Date.parse('2018-01-01') => ['email'],
+      Date.parse("2018-01-01") => ["email"],
     }
 
     assert_equal Rotas::Conflicts.annual_leave_emails_by_day([
       AnnualLeaveEvent.new(
-        email: 'email',
-        start_date: Date.parse('2018-01-01'),
-        end_date: Date.parse('2018-01-02'),
+        email: "email",
+        start_date: Date.parse("2018-01-01"),
+        end_date: Date.parse("2018-01-02"),
       ),
       AnnualLeaveEvent.new(
-        email: 'another',
-        start_date: Date.parse('2018-01-02'),
-        end_date: Date.parse('2018-01-02'),
+        email: "another",
+        start_date: Date.parse("2018-01-02"),
+        end_date: Date.parse("2018-01-02"),
       )
     ]), {
-      Date.parse('2018-01-01') => ['email'],
-      Date.parse('2018-01-02') => ['email', 'another'],
+      Date.parse("2018-01-01") => ["email"],
+      Date.parse("2018-01-02") => ["email", "another"],
     }
   end
 
-  test 'calculate_conflicts_given_calendar' do
+  test "calculate_conflicts_given_calendar" do
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
       Hash.new,
       Hash.new,
@@ -37,43 +37,43 @@ class RotasConflictTest < ActiveSupport::TestCase
 
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
       {
-        Date.parse('2018-01-01') => ['email']
+        Date.parse("2018-01-01") => ["email"]
       },
       {
-        Date.parse('2018-01-01') => [
-          Rotas::PersonDayEvent.new(nil, 'email', Date.parse('2018-01-01')),
+        Date.parse("2018-01-01") => [
+          Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-01")),
         ]
       }
     ), {
-      Date.parse('2018-01-01') => ['email']
+      Date.parse("2018-01-01") => ["email"]
     }
 
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
       {
-        Date.parse('2018-01-01') => ['email'],
-        Date.parse('2018-01-02') => ['another'],
-        Date.parse('2018-01-03') => ['email'],
+        Date.parse("2018-01-01") => ["email"],
+        Date.parse("2018-01-02") => ["another"],
+        Date.parse("2018-01-03") => ["email"],
       },
       {
-        Date.parse('2018-01-01') => [
-          Rotas::PersonDayEvent.new(nil, 'email', Date.parse('2018-01-01')),
+        Date.parse("2018-01-01") => [
+          Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-01")),
         ],
-        Date.parse('2018-01-02') => [
-          Rotas::PersonDayEvent.new(nil, 'email', Date.parse('2018-01-02')),
-          Rotas::PersonDayEvent.new(nil, 'another', Date.parse('2018-01-02')),
+        Date.parse("2018-01-02") => [
+          Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-02")),
+          Rotas::PersonDayEvent.new(nil, "another", Date.parse("2018-01-02")),
         ],
-        Date.parse('2018-01-03') => [
-          Rotas::PersonDayEvent.new(nil, 'email', Date.parse('2018-01-03')),
+        Date.parse("2018-01-03") => [
+          Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-03")),
         ],
       }
     ), {
-      Date.parse('2018-01-01') => ['email'],
-      Date.parse('2018-01-02') => ['another'],
-      Date.parse('2018-01-03') => ['email'],
+      Date.parse("2018-01-01") => ["email"],
+      Date.parse("2018-01-02") => ["another"],
+      Date.parse("2018-01-03") => ["email"],
     }
   end
 
-  test 'find' do
+  test "find" do
     assert_equal Rotas::Conflicts.find(
       Hash.new, Hash.new
     ), Hash.new
@@ -81,19 +81,19 @@ class RotasConflictTest < ActiveSupport::TestCase
     assert_equal Rotas::Conflicts.find(
       [
         AnnualLeaveEvent.new(
-          email: 'email',
-          start_date: Date.parse('2018-01-01'),
-          end_date: Date.parse('2018-01-01'),
+          email: "email",
+          start_date: Date.parse("2018-01-01"),
+          end_date: Date.parse("2018-01-01"),
         )
       ], {
-        'cal' => {
-          Date.parse('2018-01-01') => [
-            Rotas::PersonDayEvent.new(nil, 'email', Date.parse('2018-01-01')),
+        "cal" => {
+          Date.parse("2018-01-01") => [
+            Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-01")),
           ]
         },
      }), {
-      'cal' => {
-        Date.parse('2018-01-01') => ['email']
+      "cal" => {
+        Date.parse("2018-01-01") => ["email"]
       },
     }
   end

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -93,9 +93,9 @@ class RotasConflictTest < ActiveSupport::TestCase
         },
       }
     ), {
-  "cal" => {
-    Date.parse("2018-01-01") => %w[email],
-  },
-}
+      "cal" => {
+        Date.parse("2018-01-01") => %w[email],
+      },
+    }
   end
 end

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -31,9 +31,9 @@ class RotasConflictTest < ActiveSupport::TestCase
 
   test "calculate_conflicts_given_calendar" do
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
-      Hash.new,
-      Hash.new,
-    ), Hash.new
+      {},
+      {},
+    ), {}
 
     assert_equal Rotas::Conflicts.conflicts_for_calendar(
       {
@@ -75,8 +75,8 @@ class RotasConflictTest < ActiveSupport::TestCase
 
   test "find" do
     assert_equal Rotas::Conflicts.find(
-      Hash.new, Hash.new
-    ), Hash.new
+      {}, {}
+    ), {}
 
     assert_equal Rotas::Conflicts.find(
       [

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -7,7 +7,7 @@ class RotasConflictTest < ActiveSupport::TestCase
         email: "email",
         start_date: Date.parse("2018-01-01"),
         end_date: Date.parse("2018-01-01"),
-      )
+      ),
     ]), {
       Date.parse("2018-01-01") => %w[email],
     }
@@ -22,7 +22,7 @@ class RotasConflictTest < ActiveSupport::TestCase
         email: "another",
         start_date: Date.parse("2018-01-02"),
         end_date: Date.parse("2018-01-02"),
-      )
+      ),
     ]), {
       Date.parse("2018-01-01") => %w[email],
       Date.parse("2018-01-02") => %w[email another],
@@ -84,7 +84,7 @@ class RotasConflictTest < ActiveSupport::TestCase
           email: "email",
           start_date: Date.parse("2018-01-01"),
           end_date: Date.parse("2018-01-01"),
-        )
+        ),
       ], {
         "cal" => {
           Date.parse("2018-01-01") => [

--- a/test/lib/conflicts_test.rb
+++ b/test/lib/conflicts_test.rb
@@ -91,7 +91,8 @@ class RotasConflictTest < ActiveSupport::TestCase
             Rotas::PersonDayEvent.new(nil, "email", Date.parse("2018-01-01")),
           ],
         },
-      }), {
+      }
+), {
         "cal" => {
           Date.parse("2018-01-01") => %w[email],
         },

--- a/test/lib/markdown_renderer_test.rb
+++ b/test/lib/markdown_renderer_test.rb
@@ -1,12 +1,12 @@
-require 'test_helper'
+require "test_helper"
 
 def assert_same_no_ws(a, b)
-  assert_equal a.lines.map(&:strip).join(''),
-               b.lines.map(&:strip).join('')
+  assert_equal a.lines.map(&:strip).join(""),
+               b.lines.map(&:strip).join("")
 end
 
 class RotasMarkdownRendererTest < ActiveSupport::TestCase
-  test 'ul' do
+  test "ul" do
     markdown = <<~MD
       - item
       - item
@@ -24,7 +24,7 @@ class RotasMarkdownRendererTest < ActiveSupport::TestCase
     assert_same_no_ws(html, expected_html)
   end
 
-  test 'ol' do
+  test "ol" do
     markdown = <<~MD
       1. item
       1. item
@@ -42,7 +42,7 @@ class RotasMarkdownRendererTest < ActiveSupport::TestCase
     assert_same_no_ws(html, expected_html)
   end
 
-  test 'link' do
+  test "link" do
     markdown = <<~MD
       [link](https://href)
     MD
@@ -56,15 +56,15 @@ class RotasMarkdownRendererTest < ActiveSupport::TestCase
     assert_same_no_ws(html, expected_html)
   end
 
-  test 'script safe' do
+  test "script safe" do
     markdown = <<~MD
       <script>alert(1);</script>
     MD
     html = Rotas::MarkdownRenderer.render(markdown)
-    assert_equal '', html
+    assert_equal "", html
   end
 
-  test 'h1' do
+  test "h1" do
     markdown = <<~MD
       # hello
     MD
@@ -72,7 +72,7 @@ class RotasMarkdownRendererTest < ActiveSupport::TestCase
     assert_same_no_ws('<h1 class="govuk-heading-xl">hello</h1>', html)
   end
 
-  test 'h2' do
+  test "h2" do
     markdown = <<~MD
       ## hello
     MD
@@ -80,7 +80,7 @@ class RotasMarkdownRendererTest < ActiveSupport::TestCase
     assert_same_no_ws('<h2 class="govuk-heading-l">hello</h2>', html)
   end
 
-  test 'h3' do
+  test "h3" do
     markdown = <<~MD
       ### hello
     MD
@@ -88,7 +88,7 @@ class RotasMarkdownRendererTest < ActiveSupport::TestCase
     assert_same_no_ws('<h3 class="govuk-heading-m">hello</h3>', html)
   end
 
-  test 'h4' do
+  test "h4" do
     markdown = <<~MD
       #### hello
     MD
@@ -96,7 +96,7 @@ class RotasMarkdownRendererTest < ActiveSupport::TestCase
     assert_same_no_ws('<h4 class="govuk-heading-s">hello</h4>', html)
   end
 
-  test 'h5' do
+  test "h5" do
     markdown = <<~MD
       ##### hello
     MD
@@ -104,7 +104,7 @@ class RotasMarkdownRendererTest < ActiveSupport::TestCase
     assert_same_no_ws('<h5 class="govuk-heading-s">hello</h5>', html)
   end
 
-  test 'h6' do
+  test "h6" do
     markdown = <<~MD
       ###### hello
     MD

--- a/test/lib/markdown_renderer_test.rb
+++ b/test/lib/markdown_renderer_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-def assert_same_no_ws(a, b)
-  assert_equal a.lines.map(&:strip).join(""),
-               b.lines.map(&:strip).join("")
+def assert_same_no_ws(one, other)
+  assert_equal one.lines.map(&:strip).join(""),
+               other.lines.map(&:strip).join("")
 end
 
 class RotasMarkdownRendererTest < ActiveSupport::TestCase

--- a/test/models/audit_event_test.rb
+++ b/test/models/audit_event_test.rb
@@ -1,26 +1,26 @@
-require 'test_helper'
+require "test_helper"
 
 class AuditEventTest < ActiveSupport::TestCase
-  test 'happy path' do
+  test "happy path" do
     assert_empty AuditEvent.new(
-      email: 'foo@bar.com',
+      email: "foo@bar.com",
       event: {
-        message: 'did a thing'
+        message: "did a thing"
       },
     ).errors
   end
 
-  test 'email cannot be empty' do
+  test "email cannot be empty" do
     assert_empty AuditEvent.new(
       event: {
-        message: 'did a thing'
+        message: "did a thing"
       },
     ).errors
   end
 
-  test 'event cannot be empty' do
+  test "event cannot be empty" do
     assert_empty AuditEvent.new(
-      email: 'foo@bar.com',
+      email: "foo@bar.com",
     ).errors
   end
 end

--- a/test/models/audit_event_test.rb
+++ b/test/models/audit_event_test.rb
@@ -5,7 +5,7 @@ class AuditEventTest < ActiveSupport::TestCase
     assert_empty AuditEvent.new(
       email: "foo@bar.com",
       event: {
-        message: "did a thing"
+        message: "did a thing",
       },
     ).errors
   end
@@ -13,7 +13,7 @@ class AuditEventTest < ActiveSupport::TestCase
   test "email cannot be empty" do
     assert_empty AuditEvent.new(
       event: {
-        message: "did a thing"
+        message: "did a thing",
       },
     ).errors
   end

--- a/test/models/org_unit_test.rb
+++ b/test/models/org_unit_test.rb
@@ -1,8 +1,8 @@
-require 'test_helper'
+require "test_helper"
 
 class OrgUnitTest < ActiveSupport::TestCase
-  test 'org-unit has non-empty name' do
-    assert_not OrgUnit.new(name: '').valid?
-    assert OrgUnit.new(name: 'my-org-unit').valid?
+  test "org-unit has non-empty name" do
+    assert_not OrgUnit.new(name: "").valid?
+    assert OrgUnit.new(name: "my-org-unit").valid?
   end
 end

--- a/test/models/pager_duty_calendar_test.rb
+++ b/test/models/pager_duty_calendar_test.rb
@@ -14,7 +14,7 @@ class PagerDutyCalendarTest < ActiveSupport::TestCase
       name: "",
       team: @stub_team,
       url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
-			clock_type: "in_hours",
+      clock_type: "in_hours",
     ).valid?
   end
 
@@ -32,28 +32,28 @@ class PagerDutyCalendarTest < ActiveSupport::TestCase
       name: "calendar",
       team: @stub_team,
       url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
-			clock_type: :something,
+      clock_type: :something,
     ).valid?
 
     assert PagerDutyCalendar.new(
       name: "calendar",
       team: @stub_team,
       url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
-			clock_type: "in_hours",
+      clock_type: "in_hours",
     ).valid?
 
     assert PagerDutyCalendar.new(
       name: "calendar",
       team: @stub_team,
       url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
-			clock_type: "out_of_hours",
+      clock_type: "out_of_hours",
     ).valid?
 
     assert PagerDutyCalendar.new(
       name: "calendar",
       team: @stub_team,
       url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
-			clock_type: "in_and_out_of_hours",
+      clock_type: "in_and_out_of_hours",
     ).valid?
   end
 end

--- a/test/models/pager_duty_calendar_test.rb
+++ b/test/models/pager_duty_calendar_test.rb
@@ -1,59 +1,59 @@
-require 'test_helper'
+require "test_helper"
 
 class PagerDutyCalendarTest < ActiveSupport::TestCase
   setup do
-    @stub_team = Team.new(name: 'stub')
+    @stub_team = Team.new(name: "stub")
   end
 
   teardown do
     @stub_team.destroy
   end
 
-  test 'calendar must have name' do
+  test "calendar must have name" do
     assert_not PagerDutyCalendar.new(
-      name: '',
+      name: "",
       team: @stub_team,
-      url:  'https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA',
-			clock_type: 'in_hours',
+      url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
+			clock_type: "in_hours",
     ).valid?
   end
 
-  test 'calendar must reject webcal urls' do
+  test "calendar must reject webcal urls" do
     assert_not PagerDutyCalendar.new(
-      name: 'calendar',
+      name: "calendar",
       team: @stub_team,
-      url:  'webcal://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA',
-      clock_type: 'out_of_hours',
+      url:  "webcal://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
+      clock_type: "out_of_hours",
     ).valid?
   end
 
-  test 'calendar must have valid clock type' do
+  test "calendar must have valid clock type" do
     assert_not PagerDutyCalendar.new(
-      name: 'calendar',
+      name: "calendar",
       team: @stub_team,
-      url:  'https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA',
+      url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
 			clock_type: :something,
     ).valid?
 
     assert PagerDutyCalendar.new(
-      name: 'calendar',
+      name: "calendar",
       team: @stub_team,
-      url:  'https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA',
-			clock_type: 'in_hours',
+      url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
+			clock_type: "in_hours",
     ).valid?
 
     assert PagerDutyCalendar.new(
-      name: 'calendar',
+      name: "calendar",
       team: @stub_team,
-      url:  'https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA',
-			clock_type: 'out_of_hours',
+      url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
+			clock_type: "out_of_hours",
     ).valid?
 
     assert PagerDutyCalendar.new(
-      name: 'calendar',
+      name: "calendar",
       team: @stub_team,
-      url:  'https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA',
-			clock_type: 'in_and_out_of_hours',
+      url:  "https://govukpay.pagerduty.com/private/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/feed/AAAAAAA",
+			clock_type: "in_and_out_of_hours",
     ).valid?
   end
 end

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -1,35 +1,35 @@
-require 'test_helper'
+require "test_helper"
 
 class ServiceTest < ActiveSupport::TestCase
-  test 'service has non-empty name' do
-    assert_not Service.new(name: '').valid?
+  test "service has non-empty name" do
+    assert_not Service.new(name: "").valid?
   end
 
-  test 'service can have empty description' do
-    assert Service.new(name: 'my-service', description: '').valid?
+  test "service can have empty description" do
+    assert Service.new(name: "my-service", description: "").valid?
   end
 
-  test 'service can have empty documentation' do
-    assert Service.new(name: 'my-service', documentation: '').valid?
+  test "service can have empty documentation" do
+    assert Service.new(name: "my-service", documentation: "").valid?
   end
 
-  test 'service without documentation or description receives a score of 0' do
+  test "service without documentation or description receives a score of 0" do
     s = Service.new(
-      name: 'my-sad-service',
-      description: '',
-      documentation: '',
+      name: "my-sad-service",
+      description: "",
+      documentation: "",
     )
 
     assert_equal s.score, 0
   end
 
-  test 'service with docs and description and team receives a score of 5' do
-    t = Team.new(name: 'my-team')
+  test "service with docs and description and team receives a score of 5" do
+    t = Team.new(name: "my-team")
 
     s = Service.new(
-      name: 'my-happy-service',
-      description: 'my-happy-service is described',
-      documentation: 'my-happy-service is documented',
+      name: "my-happy-service",
+      description: "my-happy-service is described",
+      documentation: "my-happy-service is documented",
       teams: [t],
     )
 

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1,12 +1,12 @@
-require 'test_helper'
-require 'minitest/mock'
+require "test_helper"
+require "minitest/mock"
 
 class TeamTest < ActiveSupport::TestCase
-  test 'team has non-empty name' do
-    assert_not Team.new(name: '').valid?
+  test "team has non-empty name" do
+    assert_not Team.new(name: "").valid?
   end
 
-  test 'team has members' do
+  test "team has members" do
     team = Team.new
 
     class CalendarMock
@@ -26,11 +26,11 @@ class TeamTest < ActiveSupport::TestCase
 
     team.stub(
       :calendars, [
-        CalendarMock.new('cal1'),
-        CalendarMock.new('cal2')
+        CalendarMock.new("cal1"),
+        CalendarMock.new("cal2")
       ]
     ) do
-      assert_equal team.members, ['current@cal1', 'current@cal2']
+      assert_equal team.members, ["current@cal1", "current@cal2"]
     end
   end
 end

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -27,7 +27,7 @@ class TeamTest < ActiveSupport::TestCase
     team.stub(
       :calendars, [
         CalendarMock.new("cal1"),
-        CalendarMock.new("cal2")
+        CalendarMock.new("cal2"),
       ]
     ) do
       assert_equal team.members, ["current@cal1", "current@cal2"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
-ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
-require 'rails/test_help'
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+require "rails/test_help"
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
Updates rotas to:
- use rubocop and govuk rules, instead of govuk-lint
- use rubocop in the ruby github actions workflow