### PR TITLE
GitHub Action: Avoid issues with set-env used by older versions of setup actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      uses: ruby/setup-ruby@8bc9ca9ace0139aae24423f15269b9673354b495
       with:
         ruby-version: 2.7.1
 
@@ -34,7 +34,7 @@ jobs:
       run: bundle install
 
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.16.3
 


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
contains:
`Action authors who are using the toolkit should update the @actions/core package to v1.2.6 or greater to get the updated addPath and exportVariable functions.`
and
`Action and workflow authors who are setting environment variables via STDOUT should update any usage of the set-env and add-path workflow commands to use the new environment files.`
    
Which setup-node appear to have done in https://github.com/actions/setup-node/pull/200 - the commits for which have been tagged v2.1.2.
And which setup-ruby appear to have done in https://github.com/ruby/setup-ruby/pull/91 - the commits for which have been tagged v1.46.1.
